### PR TITLE
Add complication push type

### DIFF
--- a/Sources/APNSwift/APNSwiftConfiguration.swift
+++ b/Sources/APNSwift/APNSwiftConfiguration.swift
@@ -227,5 +227,6 @@ extension APNSwiftConnection {
         case mdm
         case voip
         case fileprovider
+        case complication
     }
 }


### PR DESCRIPTION
When working on my watch app and implementing support for using push notifications to update my watch face complications, I found out that APNSwift is missing the complication push type (which is necessary for these kind of notifications).

Since `APNSwiftConnection.PushType` enum is already backed by String, and its raw value is used when encoding the request, I found that simply adding a new case to that enum was enough to make it work.

Thank you so much for creating APNSwift, it's super useful!