### PR TITLE
Add semantic safe API for background notifications

### DIFF
--- a/Sources/APNSwift/Background/APNSBackgroundNotification.swift
+++ b/Sources/APNSwift/Background/APNSBackgroundNotification.swift
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2022 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import struct Foundation.UUID
+
+/// A background notification.
+///
+/// - Important: Your dynamic payload will get encoded to the root of the JSON payload that is send to APNs.
+/// It is **important** that you do not encode anything with the key `aps`.
+public struct APNSBackgroundNotification<Payload: Encodable>: Encodable {
+    @usableFromInline
+    struct APS: Encodable {
+        enum CodingKeys: String, CodingKey {
+            case contentAvailable = "content-available"
+        }
+
+        let contentAvailable: Int = 1
+    }
+
+    @usableFromInline
+    enum CodingKeys: CodingKey {
+        case aps
+    }
+
+    /// The fixed content to indicate that this is a background notification.
+    @usableFromInline
+    /* private */ internal let aps = APS()
+
+    /// A canonical UUID that identifies the notification. If there is an error sending the notification,
+    /// APNs uses this value to identify the notification to your server. The canonical form is 32 lowercase hexadecimal digits,
+    /// displayed in five groups separated by hyphens in the form 8-4-4-4-12. An example UUID is as follows:
+    /// `123e4567-e89b-12d3-a456-42665544000`.
+    ///
+    /// If you omit this, a new UUID is created by APNs and returned in the response.
+    public var apnsID: UUID?
+
+    /// The date when the notification is no longer valid and can be discarded. If this value is not `none`,
+    /// APNs stores the notification and tries to deliver it at least once,
+    /// repeating the attempt as needed if it is unable to deliver the notification the first time.
+    /// If the value is `immediately`, APNs treats the notification as if it expires immediately
+    /// and does not store the notification or attempt to redeliver it.
+    public var expiration: APNSNotificationExpiration
+
+    /// The topic for the notification. In general, the topic is your app’s bundle ID/app ID.
+    public var topic: String
+
+    /// Your custom payload.
+    public var payload: Payload
+
+    /// Initializes a new ``APNSBackgroundNotification``.
+    ///
+    /// - Important: Your dynamic payload will get encoded to the root of the JSON payload that is send to APNs.
+    /// It is **important** that you do not encode anything with the key `aps`
+    ///
+    /// - Parameters:
+    ///   - payload: Your custom payload.
+    ///
+    ///   - expiration: The date when the notification is no longer valid and can be discarded.
+    ///
+    ///   - topic: The topic for the notification. In general, the topic is your app’s bundle ID/app ID.
+    ///
+    ///   - apnsID: A canonical UUID that identifies the notification.
+    @inlinable
+    public init(
+        expiration: APNSNotificationExpiration,
+        topic: String,
+        payload: Payload,
+        apnsID: UUID? = nil
+    ) {
+        self.payload = payload
+        self.apnsID = apnsID
+        self.expiration = expiration
+        self.topic = topic
+    }
+
+    @inlinable
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        // First we encode the user payload since this might use the `aps` key
+        // and we override it afterward.
+        try self.payload.encode(to: encoder)
+        try container.encode(self.aps, forKey: .aps)
+    }
+}

--- a/Sources/APNSwift/Background/APNSClient+Background.swift
+++ b/Sources/APNSwift/Background/APNSClient+Background.swift
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2022 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import Logging
+
+extension APNSClient {
+    /// Sends a background update notification to APNs.
+    ///
+    /// - Parameters:
+    ///   - notification: The notification to send.
+    ///
+    ///   - deviceToken: The hexadecimal bytes that identify the user’s device. Your app receives the bytes for this device token
+    ///    when registering for remote notifications.
+    ///
+    ///   - deadline: Point in time by which sending the notification to APNs must complete.
+    ///
+    ///   - logger: The logger to use for sending this notification.
+    @discardableResult
+    @inlinable
+    public func sendBackgroundNotification<Payload: Encodable>(
+        _ notification: APNSBackgroundNotification<Payload>,
+        deviceToken: String,
+        deadline: NIODeadline,
+        logger: Logger = _noOpLogger
+    ) async throws -> APNSResponse {
+        try await self.send(
+            payload: notification,
+            deviceToken: deviceToken,
+            pushType: .background,
+            apnsID: notification.apnsID,
+            expiration: notification.expiration,
+            priority: .consideringDevicePower,
+            topic: notification.topic,
+            deadline: deadline,
+            logger: logger
+        )
+    }
+}

--- a/Tests/APNSwiftTests/Background/APNSBackgroundNotificationTests.swift
+++ b/Tests/APNSwiftTests/Background/APNSBackgroundNotificationTests.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2022 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import APNSwift
+import XCTest
+
+final class APNSBackgroundNotificationTests: XCTestCase {
+    func testEncode() throws {
+        struct Payload: Encodable {
+            let foo = "bar"
+        }
+        let notification = APNSBackgroundNotification(
+            expiration: .none,
+            topic: "com.test.app",
+            payload: Payload(),
+            apnsID: nil
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(notification)
+
+        let expectedJSONString = """
+        {"foo":"bar","aps":{"content-available":1}}
+        """
+        let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+        let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
+        XCTAssertEqual(jsonObject1, jsonObject2)
+    }
+
+    func testEnode_whenAPSKeyInPayload() throws {
+        struct Payload: Encodable {
+            let aps = "foo"
+        }
+        let notification = APNSBackgroundNotification(
+            expiration: .none,
+            topic: "com.test.app",
+            payload: Payload(),
+            apnsID: nil
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(notification)
+
+        let expectedJSONString = """
+        {"aps":{"content-available":1}}
+        """
+        let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+        let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
+        XCTAssertEqual(jsonObject1, jsonObject2)
+    }
+}


### PR DESCRIPTION
# Motivation
We want to provide new APIs that are semantically safe when sending background notifications to APNs.

# Modification
The PR adds new types for the background notification and a convenience method to send it notifications with the APNSClient.

# Result
We can now send background notifications.