### PR TITLE
Add semantic safe API for VoIP notifications

### DIFF
--- a/Sources/APNSwift/VoIP/APNSClient+VoIP.swift
+++ b/Sources/APNSwift/VoIP/APNSClient+VoIP.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2022 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import Logging
+
+extension APNSClient {
+    /// Sends a VoIP notification to APNs.
+    ///
+    /// - Parameters:
+    ///   - notification: The notification to send.
+    ///
+    ///   - deviceToken: The hexadecimal bytes that identify the user’s device. Your app receives the bytes for this device token
+    ///    when registering for remote notifications.
+    ///
+    ///   - deadline: Point in time by which sending the notification to APNs must complete.
+    ///
+    ///   - logger: The logger to use for sending this notification.
+    @discardableResult
+    @inlinable
+    public func sendVoIPNotification<Payload: Encodable>(
+        _ notification: APNSVoIPNotification<Payload>,
+        deviceToken: String,
+        deadline: NIODeadline,
+        logger: Logger = _noOpLogger
+    ) async throws -> APNSResponse {
+        try await self.send(
+            payload: notification.payload,
+            deviceToken: deviceToken,
+            pushType: .voip,
+            expiration: notification.expiration,
+            priority: notification.priority,
+            topic: notification.topic,
+            deadline: deadline,
+            logger: logger
+        )
+    }
+}

--- a/Sources/APNSwift/VoIP/APNSVoIPNotification.swift
+++ b/Sources/APNSwift/VoIP/APNSVoIPNotification.swift
@@ -1,0 +1,97 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2022 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import struct Foundation.UUID
+
+/// A voice-over-IP notification.
+public struct APNSVoIPNotification<Payload: Encodable> {
+    /// A canonical UUID that identifies the notification. If there is an error sending the notification,
+    /// APNs uses this value to identify the notification to your server. The canonical form is 32 lowercase hexadecimal digits,
+    /// displayed in five groups separated by hyphens in the form 8-4-4-4-12. An example UUID is as follows:
+    /// `123e4567-e89b-12d3-a456-42665544000`.
+    ///
+    /// If you omit this, a new UUID is created by APNs and returned in the response.
+    public var apnsID: UUID?
+
+    /// The topic for the notification. In general, the topic is your app’s bundle ID/app ID suffixed with `.voip`.
+    public var topic: String
+
+    /// The date when the notification is no longer valid and can be discarded. If this value is not `none`,
+    /// APNs stores the notification and tries to deliver it at least once,
+    /// repeating the attempt as needed if it is unable to deliver the notification the first time.
+    /// If the value is `immediately`, APNs treats the notification as if it expires immediately
+    /// and does not store the notification or attempt to redeliver it.
+    public var expiration: APNSNotificationExpiration
+
+    /// The priority of the notification.
+    public var priority: APNSPriority
+
+    /// Your custom payload.
+    public var payload: Payload
+
+    /// Initializes a new ``APNSVoIPNotification``.
+    ///
+    /// - Important: Your dynamic payload will get encoded to the root of the JSON payload that is send to APNs.
+    /// It is **important** that you do not encode anything with the key `aps`
+    ///
+    /// - Parameters:
+    ///   - expiration: The date when the notification is no longer valid and can be discarded. Defaults to `.immediately`
+    ///   - priority: The priority of the notification.
+    ///   - appID: Your app’s bundle ID/app ID. This will be suffixed with `.voip`.
+    ///   - payload: Your custom payload.
+    ///   - apnsID: A canonical UUID that identifies the notification.
+    @inlinable
+    public init(
+        expiration: APNSNotificationExpiration = .immediately,
+        priority: APNSPriority,
+        appID: String,
+        payload: Payload,
+        apnsID: UUID? = nil
+    ) {
+        self.init(
+            expiration: expiration,
+            priority: priority,
+            topic: appID + ".voip",
+            payload: payload,
+            apnsID: apnsID
+        )
+    }
+
+    /// Initializes a new ``APNSVoIPNotification``.
+    ///
+    /// - Important: Your dynamic payload will get encoded to the root of the JSON payload that is send to APNs.
+    /// It is **important** that you do not encode anything with the key `aps`
+    ///
+    /// - Parameters:
+    ///   - expiration: The date when the notification is no longer valid and can be discarded. Defaults to `.immediately`
+    ///   - priority: The priority of the notification.
+    ///   - topic: The topic for the notification. In general, the topic is your app’s bundle ID/app ID suffixed with `.voip`.
+    ///   - payload: Your custom payload.
+    ///   - apnsID: A canonical UUID that identifies the notification.
+    @inlinable
+    public init(
+        expiration: APNSNotificationExpiration = .immediately,
+        priority: APNSPriority,
+        topic: String,
+        payload: Payload,
+        apnsID: UUID? = nil
+    ) {
+        self.expiration = expiration
+        self.priority = priority
+        self.topic = topic
+        self.payload = payload
+        self.apnsID = apnsID
+    }
+}
+

--- a/Sources/APNSwiftExample/Program.swift
+++ b/Sources/APNSwiftExample/Program.swift
@@ -66,6 +66,8 @@ struct Main {
             try await Self.sendThreadedAlert(with: client)
             try await Self.sendCustomCategoryAlert(with: client)
             try await Self.sendMutableContentAlert(with: client)
+            try await Self.sendBackground(with: client)
+            try await Self.sendVoIP(with: client)
         } catch {
             self.logger.error("Failed sending push", metadata: ["error": "\(error)"])
         }
@@ -174,6 +176,43 @@ extension Main {
                 mutableContent: 1
             ),
             deviceToken: self.deviceToken,
+            deadline: .distantFuture,
+            logger: self.logger
+        )
+    }
+}
+
+// MARK: Background
+
+@available(macOS 11.0, *)
+extension Main {
+    static func sendBackground(with client: APNSClient<JSONDecoder, JSONEncoder>) async throws {
+        try await client.sendBackgroundNotification(
+            .init(
+                expiration: .immediately,
+                topic: self.appBundleID,
+                payload: Payload()
+            ),
+            deviceToken: self.deviceToken,
+            deadline: .distantFuture,
+            logger: self.logger
+        )
+    }
+}
+
+// MARK: VoIP
+
+@available(macOS 11.0, *)
+extension Main {
+    static func sendVoIP(with client: APNSClient<JSONDecoder, JSONEncoder>) async throws {
+        try await client.sendVoIPNotification(
+            .init(
+                expiration: .immediately,
+                priority: .immediately,
+                appID: self.appBundleID,
+                payload: Payload()
+            ),
+            deviceToken: self.pushKitDeviceToken,
             deadline: .distantFuture,
             logger: self.logger
         )

--- a/Tests/APNSwiftTests/VoIP/APNSVoIPNotificationTests.swift
+++ b/Tests/APNSwiftTests/VoIP/APNSVoIPNotificationTests.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2022 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import APNSwift
+import XCTest
+
+final class APNSVoIPNotificationTests: XCTestCase {
+    func testAppID() {
+        struct Payload: Encodable {
+            let foo = "bar"
+        }
+        let voipNotification = APNSVoIPNotification(
+            priority: .immediately,
+            appID: "com.example.app",
+            payload: Payload()
+        )
+
+        XCTAssertEqual(voipNotification.topic, "com.example.app.voip")
+    }
+}


### PR DESCRIPTION
# Motivation
We want to provide new APIs that are semantically safe when sending VoIP notifications to APNs.

# Modification
The PR adds new types for the VoIP notification and a convenience method to send it notifications with the APNSClient.

# Result
We can now send VoIP notifications.