### PR TITLE
Add semantic safe API for Complication notifications

### DIFF
--- a/Sources/APNSwift/Complication/APNSClient+Complication.swift
+++ b/Sources/APNSwift/Complication/APNSClient+Complication.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2022 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+import NIOCore
+
+extension APNSClient {
+    /// Sends a complication notification to APNs.
+    ///
+    /// - Parameters:
+    ///   - notification: The notification to send.
+    ///
+    ///   - deviceToken: The hexadecimal bytes that identify the user’s device. Your app receives the bytes for this device token
+    ///    when registering for remote notifications.
+    ///
+    ///   - deadline: Point in time by which sending the notification to APNs must complete.
+    ///
+    ///   - logger: The logger to use for sending this notification.
+    @discardableResult
+    @inlinable
+    public func sendComplicationNotification<Payload: Encodable>(
+        _ notification: APNSComplicationNotification<Payload>,
+        deviceToken: String,
+        deadline: NIODeadline,
+        logger: Logger = _noOpLogger
+    ) async throws -> APNSResponse {
+        try await self.send(
+            payload: notification.payload,
+            deviceToken: deviceToken,
+            pushType: .complication,
+            expiration: notification.expiration,
+            priority: notification.priority,
+            topic: notification.topic,
+            deadline: deadline,
+            logger: logger
+        )
+    }
+}

--- a/Sources/APNSwift/Complication/APNSComplicationNotification.swift
+++ b/Sources/APNSwift/Complication/APNSComplicationNotification.swift
@@ -1,0 +1,93 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2022 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import struct Foundation.UUID
+
+/// A complication notification.
+public struct APNSComplicationNotification<Payload: Encodable> {
+    /// A canonical UUID that identifies the notification. If there is an error sending the notification,
+    /// APNs uses this value to identify the notification to your server. The canonical form is 32 lowercase hexadecimal digits,
+    /// displayed in five groups separated by hyphens in the form 8-4-4-4-12. An example UUID is as follows:
+    /// `123e4567-e89b-12d3-a456-42665544000`.
+    ///
+    /// If you omit this, a new UUID is created by APNs and returned in the response.
+    public var apnsID: UUID?
+
+    /// The topic for the notification. In general, the topic is your app’s bundle ID/app ID suffixed with `.complication`.
+    public var topic: String
+
+    /// The date when the notification is no longer valid and can be discarded. If this value is not `none`,
+    /// APNs stores the notification and tries to deliver it at least once,
+    /// repeating the attempt as needed if it is unable to deliver the notification the first time.
+    /// If the value is `immediately`, APNs treats the notification as if it expires immediately
+    /// and does not store the notification or attempt to redeliver it.
+    public var expiration: APNSNotificationExpiration
+
+    /// The priority of the notification.
+    public var priority: APNSPriority
+
+    /// Your custom payload.
+    public var payload: Payload
+
+    /// Initializes a new ``APNSComplicationNotification``.
+    ///
+    /// - Parameters:
+    ///   - expiration: The date when the notification is no longer valid and can be discarded.
+    ///   - priority: The priority of the notification.
+    ///   - appID: Your app’s bundle ID/app ID. This will be suffixed with `.complication`.
+    ///   - payload: Your custom payload.
+    ///   - apnsID: A canonical UUID that identifies the notification.
+    @inlinable
+    public init(
+        expiration: APNSNotificationExpiration,
+        priority: APNSPriority,
+        appID: String,
+        payload: Payload,
+        apnsID: UUID? = nil
+    ) {
+        self.init(
+            expiration: expiration,
+            priority: priority,
+            topic: appID + ".complication",
+            payload: payload,
+            apnsID: apnsID
+        )
+    }
+
+    /// Initializes a new ``APNSVoIPNotification``.
+    ///
+    /// - Important: Your dynamic payload will get encoded to the root of the JSON payload that is send to APNs.
+    /// It is **important** that you do not encode anything with the key `aps`
+    ///
+    /// - Parameters:
+    ///   - expiration: The date when the notification is no longer valid and can be discarded.
+    ///   - priority: The priority of the notification.
+    ///   - topic: The topic for the notification. In general, the topic is your app’s bundle ID/app ID suffixed with `.complication`.
+    ///   - payload: Your custom payload.
+    ///   - apnsID: A canonical UUID that identifies the notification.
+    @inlinable
+    public init(
+        expiration: APNSNotificationExpiration,
+        priority: APNSPriority,
+        topic: String,
+        payload: Payload,
+        apnsID: UUID? = nil
+    ) {
+        self.expiration = expiration
+        self.priority = priority
+        self.topic = topic
+        self.payload = payload
+        self.apnsID = apnsID
+    }
+}

--- a/Tests/APNSwiftTests/Complication/APNSComplicationNotificationTests.swift
+++ b/Tests/APNSwiftTests/Complication/APNSComplicationNotificationTests.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2022 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import APNSwift
+import XCTest
+
+final class APNSComplicationNotificationTests: XCTestCase {
+    func testAppID() {
+        struct Payload: Encodable {
+            let foo = "bar"
+        }
+        let complicationNotification = APNSComplicationNotification(
+            expiration: .immediately,
+            priority: .immediately,
+            appID: "com.example.app",
+            payload: Payload()
+        )
+
+        XCTAssertEqual(complicationNotification.topic, "com.example.app.complication")
+    }
+}


### PR DESCRIPTION
# Motivation
We want to provide new APIs that are semantically safe when sending Complication notifications to APNs.

# Modification
The PR adds new types for the Complication notification and a convenience method to send it notifications with the APNSClient.

# Result
We can now send Complication notifications.