### PR TITLE
Update .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,5 +1,5 @@
 version: 1
 builder:
   configs:
-    - documentation_targets: [APNSwift]
+    - documentation_targets: [APNS]
       scheme: APNSwift


### PR DESCRIPTION
Documentation generation is [currently failing](https://swiftpackageindex.com/builds/53600FD4-84D8-47D0-AC3F-67CB035C2701) in SPI:

```
error: no target named 'APNSwift'

compatible targets: 'APNSExample', 'APNS', 'APNSCore', 'APNSURLSession', 'APNSTestServer', 'Crypto', 'AsyncHTTPClient', 'Logging', 'NIOCore', 'NIOPosix', 'NIOSSL', 'NIOHTTP1', 'NIOHTTP2'"
```

I believe the intended target is simply `APNS`.