### PR TITLE
Make APNSError.reason public again

### DIFF
--- a/Sources/APNSCore/APNSError.swift
+++ b/Sources/APNSCore/APNSError.swift
@@ -395,7 +395,7 @@ public struct APNSError: Error {
     public let apnsID: UUID?
 
     /// The error code indicating the reason for the failure.
-    private let reason: ErrorReason?
+    public let reason: ErrorReason?
 
     /// The date at which APNs confirmed the token was no longer valid for the topic.
     ///


### PR DESCRIPTION
This commit restores public access to the `APNSError.reason` property, because it's needed for library users handling APNs errors.  (The status code is not an viable alternative, as there are multiple different error reasons for one status code.)

The `reason` property was unintentionally set to private in commit ecf0f4465 (Breakout APNSwift into packages (#170)). Notably, the associated type ErrorReason remained public.