### PR TITLE
support send raw payload data

### DIFF
--- a/Sources/APNSCore/APNSRequest.swift
+++ b/Sources/APNSCore/APNSRequest.swift
@@ -12,9 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct Foundation.UUID
+import Foundation
 
 public struct APNSRequest<Message: APNSMessage> {
+    
     fileprivate final class _Storage {
         var message: Message
         var deviceToken: String
@@ -24,6 +25,7 @@ public struct APNSRequest<Message: APNSMessage> {
         var apnsID: UUID?
         var topic: String?
         var collapseID: String?
+        var rawPayloadData: Foundation.Data?
         
         init(
             message: Message,
@@ -33,7 +35,8 @@ public struct APNSRequest<Message: APNSMessage> {
             priority: APNSPriority?,
             apnsID: UUID?,
             topic: String?,
-            collapseID: String?
+            collapseID: String?,
+            rawPayloadData: Data?
         ) {
             self.message = message
             self.deviceToken = deviceToken
@@ -43,6 +46,7 @@ public struct APNSRequest<Message: APNSMessage> {
             self.apnsID = apnsID
             self.topic = topic
             self.collapseID = collapseID
+            self.rawPayloadData = rawPayloadData
         }
     }
 
@@ -81,6 +85,7 @@ public struct APNSRequest<Message: APNSMessage> {
         
         return computedHeaders
     }
+    
     public init(
         message: Message,
         deviceToken: String,
@@ -89,7 +94,8 @@ public struct APNSRequest<Message: APNSMessage> {
         priority: APNSPriority?,
         apnsID: UUID?,
         topic: String?,
-        collapseID: String?
+        collapseID: String?,
+        rawPayloadData: Data?
     ) {
         self._storage = _Storage(
             message: message,
@@ -99,7 +105,8 @@ public struct APNSRequest<Message: APNSMessage> {
             priority: priority,
             apnsID: apnsID,
             topic: topic,
-            collapseID: collapseID
+            collapseID: collapseID,
+            rawPayloadData: rawPayloadData
         )
     }
 }
@@ -114,7 +121,8 @@ extension APNSRequest._Storage {
             priority: priority,
             apnsID: apnsID,
             topic: topic,
-            collapseID: collapseID
+            collapseID: collapseID,
+            rawPayloadData: rawPayloadData
         )
     }
 }
@@ -214,6 +222,18 @@ extension APNSRequest {
                 self._storage = self._storage.copy()
             }
             self._storage.collapseID = newValue
+        }
+    }
+    
+    public var rawPayloadData: Data? {
+        get {
+            return self._storage.rawPayloadData
+        }
+        set {
+            if !isKnownUniquelyReferenced(&self._storage) {
+                self._storage = self._storage.copy()
+            }
+            self._storage.rawPayloadData = newValue
         }
     }
 }

--- a/Sources/APNSCore/Alert/APNSAlertNotification.swift
+++ b/Sources/APNSCore/Alert/APNSAlertNotification.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct Foundation.UUID
+import Foundation
 
 /// An alert notification.
 ///
@@ -156,6 +156,9 @@ public struct APNSAlertNotification<Payload: Encodable & Sendable>: APNSMessage,
 
     /// Your custom payload.
     public var payload: Payload
+    
+    /// Your whole raw payload data
+    public var rawPayloadData: Data?
 
     /// Initializes a new ``APNSAlertNotification``.
     ///
@@ -183,6 +186,7 @@ public struct APNSAlertNotification<Payload: Encodable & Sendable>: APNSMessage,
         priority: APNSPriority,
         topic: String,
         payload: Payload,
+        rawPayloadData: Data? = nil,
         badge: Int? = nil,
         sound: APNSAlertNotificationSound? = nil,
         threadID: String? = nil,
@@ -209,6 +213,7 @@ public struct APNSAlertNotification<Payload: Encodable & Sendable>: APNSMessage,
         self.priority = priority
         self.topic = topic
         self.payload = payload
+        self.rawPayloadData = rawPayloadData
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -254,7 +259,8 @@ extension APNSAlertNotification where Payload == EmptyPayload {
         targetContentID: String? = nil,
         interruptionLevel: APNSAlertNotificationInterruptionLevel? = nil,
         relevanceScore: Double? = nil,
-        apnsID: UUID? = nil
+        apnsID: UUID? = nil,
+        rawPayloadData: Data? = nil
     ) {
         self.aps = APNSAlertNotificationAPSStorage(
             alert: alert,
@@ -272,5 +278,6 @@ extension APNSAlertNotification where Payload == EmptyPayload {
         self.priority = priority
         self.topic = topic
         self.payload = EmptyPayload()
+        self.rawPayloadData = rawPayloadData
     }
 }

--- a/Sources/APNSCore/Alert/APNSClient+Alert.swift
+++ b/Sources/APNSCore/Alert/APNSClient+Alert.swift
@@ -38,7 +38,8 @@ extension APNSClientProtocol {
             priority: notification.priority,
             apnsID: notification.apnsID,
             topic: notification.topic,
-            collapseID: notification.collapseID
+            collapseID: notification.collapseID,
+            rawPayloadData: notification.rawPayloadData
         )
         return try await send(request)
     }

--- a/Sources/APNSCore/Background/APNSBackgroundNotification.swift
+++ b/Sources/APNSCore/Background/APNSBackgroundNotification.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct Foundation.UUID
+import Foundation
 
 /// A background notification.
 ///
@@ -57,6 +57,9 @@ public struct APNSBackgroundNotification<Payload: Encodable & Sendable>: APNSMes
 
     /// Your custom payload.
     public var payload: Payload
+    
+    /// Your whole raw payload data
+    public var rawPayloadData: Data?
 
     /// Initializes a new ``APNSBackgroundNotification``.
     ///
@@ -76,9 +79,11 @@ public struct APNSBackgroundNotification<Payload: Encodable & Sendable>: APNSMes
         expiration: APNSNotificationExpiration,
         topic: String,
         payload: Payload,
+        rawPayloadData: Data? = nil,
         apnsID: UUID? = nil
     ) {
         self.payload = payload
+        self.rawPayloadData = rawPayloadData
         self.apnsID = apnsID
         self.expiration = expiration
         self.topic = topic
@@ -99,12 +104,14 @@ extension APNSBackgroundNotification where Payload == EmptyPayload {
     public init(
         expiration: APNSNotificationExpiration,
         topic: String,
-        apnsID: UUID? = nil
+        apnsID: UUID? = nil,
+        rawPayloadData: Data? = nil
     ) {
         self.init(
             expiration: expiration,
             topic: topic,
             payload: EmptyPayload(),
+            rawPayloadData: rawPayloadData,
             apnsID: apnsID
         )
     }

--- a/Sources/APNSCore/Background/APNSClient+Background.swift
+++ b/Sources/APNSCore/Background/APNSClient+Background.swift
@@ -38,7 +38,8 @@ extension APNSClientProtocol {
             priority: .consideringDevicePower,
             apnsID: notification.apnsID,
             topic: notification.topic,
-            collapseID: nil
+            collapseID: nil,
+            rawPayloadData: notification.rawPayloadData
         )
         return try await send(request)
     }

--- a/Sources/APNSCore/Complication/APNSClient+Complication.swift
+++ b/Sources/APNSCore/Complication/APNSClient+Complication.swift
@@ -37,7 +37,8 @@ extension APNSClientProtocol {
             priority: notification.priority,
             apnsID: notification.apnsID,
             topic: notification.topic,
-            collapseID: nil
+            collapseID: nil,
+            rawPayloadData: notification.rawPayloadData
         )
         return try await send(request)
     }

--- a/Sources/APNSCore/Complication/APNSComplicationNotification.swift
+++ b/Sources/APNSCore/Complication/APNSComplicationNotification.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct Foundation.UUID
+import Foundation
 
 /// A complication notification.
 public struct APNSComplicationNotification<Payload: Encodable & Sendable>: APNSMessage {
@@ -39,6 +39,9 @@ public struct APNSComplicationNotification<Payload: Encodable & Sendable>: APNSM
 
     /// Your custom payload.
     public var payload: Payload
+    
+    /// Your whole raw payload data
+    public var rawPayloadData: Data?
 
     /// Initializes a new ``APNSComplicationNotification``.
     ///
@@ -54,6 +57,7 @@ public struct APNSComplicationNotification<Payload: Encodable & Sendable>: APNSM
         priority: APNSPriority,
         appID: String,
         payload: Payload,
+        rawPayloadData: Data? = nil,
         apnsID: UUID? = nil
     ) {
         self.init(
@@ -61,6 +65,7 @@ public struct APNSComplicationNotification<Payload: Encodable & Sendable>: APNSM
             priority: priority,
             topic: appID + ".complication",
             payload: payload,
+            rawPayloadData: rawPayloadData,
             apnsID: apnsID
         )
     }
@@ -82,12 +87,14 @@ public struct APNSComplicationNotification<Payload: Encodable & Sendable>: APNSM
         priority: APNSPriority,
         topic: String,
         payload: Payload,
+        rawPayloadData: Data? = nil,
         apnsID: UUID? = nil
     ) {
         self.expiration = expiration
         self.priority = priority
         self.topic = topic
         self.payload = payload
+        self.rawPayloadData = rawPayloadData
         self.apnsID = apnsID
     }
 }
@@ -105,13 +112,15 @@ extension APNSComplicationNotification where Payload == EmptyPayload {
         expiration: APNSNotificationExpiration,
         priority: APNSPriority,
         appID: String,
-        apnsID: UUID? = nil
+        apnsID: UUID? = nil,
+        rawPayloadData: Data? = nil
     ) {
         self.init(
             expiration: expiration,
             priority: priority,
             topic: appID + ".complication",
             payload: EmptyPayload(),
+            rawPayloadData: rawPayloadData,
             apnsID: apnsID
         )
     }

--- a/Sources/APNSCore/FileProvider/APNSClient+FileProvider.swift
+++ b/Sources/APNSCore/FileProvider/APNSClient+FileProvider.swift
@@ -38,7 +38,8 @@ extension APNSClientProtocol {
             priority: .consideringDevicePower,
             apnsID: notification.apnsID,
             topic: notification.topic,
-            collapseID: nil
+            collapseID: nil,
+            rawPayloadData: notification.rawPayloadData
         )
         return try await send(request)
     }

--- a/Sources/APNSCore/FileProvider/APNSFileProviderNotification.swift
+++ b/Sources/APNSCore/FileProvider/APNSFileProviderNotification.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct Foundation.UUID
+import Foundation
 
 /// A file provider notification.
 public struct APNSFileProviderNotification<Payload: Encodable & Sendable>: APNSMessage {
@@ -37,6 +37,9 @@ public struct APNSFileProviderNotification<Payload: Encodable & Sendable>: APNSM
     /// Your custom payload.
     public var payload: Payload
 
+    /// Your whole raw payload data
+    public var rawPayloadData: Data?
+    
     /// Initializes a new ``APNSFileProviderNotification``.
     ///
     /// - Parameters:
@@ -49,12 +52,14 @@ public struct APNSFileProviderNotification<Payload: Encodable & Sendable>: APNSM
         expiration: APNSNotificationExpiration,
         appID: String,
         payload: Payload,
+        rawPayloadData: Data? = nil,
         apnsID: UUID? = nil
     ) {
         self.init(
             expiration: expiration,
             topic: appID + ".pushkit.fileprovider",
             payload: payload,
+            rawPayloadData: rawPayloadData,
             apnsID: apnsID
         )
     }
@@ -74,11 +79,13 @@ public struct APNSFileProviderNotification<Payload: Encodable & Sendable>: APNSM
         expiration: APNSNotificationExpiration,
         topic: String,
         payload: Payload,
+        rawPayloadData: Data? = nil,
         apnsID: UUID? = nil
     ) {
         self.expiration = expiration
         self.topic = topic
         self.payload = payload
+        self.rawPayloadData = rawPayloadData
         self.apnsID = apnsID
     }
 }
@@ -94,12 +101,14 @@ extension APNSFileProviderNotification where Payload == EmptyPayload {
     public init(
         expiration: APNSNotificationExpiration,
         appID: String,
-        apnsID: UUID? = nil
+        apnsID: UUID? = nil,
+        rawPayloadData: Data? = nil
     ) {
         self.init(
             expiration: expiration,
             topic: appID + ".pushkit.fileprovider",
             payload: EmptyPayload(),
+            rawPayloadData: rawPayloadData,
             apnsID: apnsID
         )
     }

--- a/Sources/APNSCore/LiveActivity/APNSClient+LiveActivity.swift
+++ b/Sources/APNSCore/LiveActivity/APNSClient+LiveActivity.swift
@@ -37,7 +37,8 @@ extension APNSClientProtocol {
             priority: notification.priority,
             apnsID: notification.apnsID,
             topic: notification.topic,
-            collapseID: nil
+            collapseID: nil,
+            rawPayloadData: nil
         )
         return try await send(request)
     }

--- a/Sources/APNSCore/Location/APNSClient+Location.swift
+++ b/Sources/APNSCore/Location/APNSClient+Location.swift
@@ -37,7 +37,8 @@ extension APNSClientProtocol {
             priority: notification.priority,
             apnsID: notification.apnsID,
             topic: notification.topic,
-            collapseID: nil
+            collapseID: nil,
+            rawPayloadData: nil
         )
         return try await send(request)
     }

--- a/Sources/APNSCore/VoIP/APNSClient+VoIP.swift
+++ b/Sources/APNSCore/VoIP/APNSClient+VoIP.swift
@@ -38,7 +38,8 @@ extension APNSClientProtocol {
             priority: notification.priority,
             apnsID: notification.apnsID,
             topic: notification.topic,
-            collapseID: nil
+            collapseID: nil,
+            rawPayloadData: notification.rawPayloadData
         )
         return try await send(request)
     }

--- a/Sources/APNSCore/VoIP/APNSVoIPNotification.swift
+++ b/Sources/APNSCore/VoIP/APNSVoIPNotification.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct Foundation.UUID
+import Foundation
 
 /// A voice-over-IP notification.
 public struct APNSVoIPNotification<Payload: Encodable & Sendable>: APNSMessage {
@@ -39,6 +39,9 @@ public struct APNSVoIPNotification<Payload: Encodable & Sendable>: APNSMessage {
 
     /// Your custom payload.
     public var payload: Payload
+    
+    /// Your whole raw payload data
+    public var rawPayloadData: Data?
 
     /// Initializes a new ``APNSVoIPNotification``.
     ///
@@ -57,6 +60,7 @@ public struct APNSVoIPNotification<Payload: Encodable & Sendable>: APNSMessage {
         priority: APNSPriority,
         appID: String,
         payload: Payload,
+        rawPayloadData: Data? = nil,
         apnsID: UUID? = nil
     ) {
         self.init(
@@ -64,6 +68,7 @@ public struct APNSVoIPNotification<Payload: Encodable & Sendable>: APNSMessage {
             priority: priority,
             topic: appID + ".voip",
             payload: payload,
+            rawPayloadData: rawPayloadData,
             apnsID: apnsID
         )
     }
@@ -85,12 +90,14 @@ public struct APNSVoIPNotification<Payload: Encodable & Sendable>: APNSMessage {
         priority: APNSPriority,
         topic: String,
         payload: Payload,
+        rawPayloadData: Data? = nil,
         apnsID: UUID? = nil
     ) {
         self.expiration = expiration
         self.priority = priority
         self.topic = topic
         self.payload = payload
+        self.rawPayloadData = rawPayloadData
         self.apnsID = apnsID
     }
 }
@@ -111,13 +118,15 @@ extension APNSVoIPNotification where Payload == EmptyPayload {
         expiration: APNSNotificationExpiration = .immediately,
         priority: APNSPriority,
         appID: String,
-        apnsID: UUID? = nil
+        apnsID: UUID? = nil,
+        rawPayloadData: Data? = nil
     ) {
         self.init(
             expiration: expiration,
             priority: priority,
             topic: appID + ".voip",
             payload: EmptyPayload(),
+            rawPayloadData: rawPayloadData,
             apnsID: apnsID
         )
     }


### PR DESCRIPTION
such as the json string payload could be transform to data and be sent 

If the rawPayloadData be set, message would not been encoded into bytebuffer, the rawPayloadData as the whole post request body bytes.

If rawPayloadData is nil, the send logic is same as the 5.0.0, that is the message been encoded into post request body and be sent.

There is an example use it:
```swift
      var client = APNSClient(
          configuration: .init(
              authenticationMethod: .jwt(
                  privateKey: try .init(pemRepresentation: config.privateKey),
                  keyIdentifier: config.keyIdentifier,
                  teamIdentifier: config.teamIdentifier
              ),
              environment: config.apnsServerEnv.env
          ),
          eventLoopGroupProvider: .createNew,
          responseDecoder: JSONDecoder(),
          requestEncoder: JSONEncoder()
      )

      guard let payloadData = """
      {
        "aps": {
          "alert": {
            "body": "Body Content",
            "subtitle": "Subtitle Content",
            "title": "Simple Alert Content"
          }
        },
        "o_url": "https://www.baidu.com",
        "obj": {
          "key1": "value",
          "key2": 2
        }
      }
      """.data(using: .utf8)
      else {
          return false
      }
      
      var response: APNSResponse?
      switch config.pushType {
      case .alert:
          response = try await client?.sendAlertNotification(
              .init(
                  alert: .init(
                      title: .raw("Simple Alert"),
                      subtitle: .raw("Subtitle"),
                      body: .raw("Body")),
                  expiration: .immediately,
                  priority: .immediately,
                  topic: config.appBundleID,
                  rawPayloadData: payloadData
              ),
              deviceToken: config.deviceToken)
      case .background:
          response = try await client?.sendBackgroundNotification(
              .init(
                  expiration: .immediately,
                  topic: config.appBundleID,
                  rawPayloadData: payloadData
              ),
              deviceToken: config.deviceToken)
      case .voip:
          response = try await client?.sendVoIPNotification(
              .init(
                  priority: .immediately,
                  appID: config.appBundleID,
                  rawPayloadData: payloadData
              ),
              deviceToken: config.pushKitVoIPToken)
      case .fileprovider:
          response = try await client?.sendFileProviderNotification(
              .init(
                  expiration: .immediately,
                  appID: config.appBundleID,
                  rawPayloadData: payloadData
              ),
              deviceToken: config.pushKitFileProviderToken)
      }

```