### PR TITLE
Update APNSClient+Location.swift

### DIFF
--- a/Sources/APNSCore/Location/APNSClient+Location.swift
+++ b/Sources/APNSCore/Location/APNSClient+Location.swift
@@ -25,7 +25,7 @@ extension APNSClientProtocol {
     ///   - logger: The logger to use for sending this notification.
     @discardableResult
     @inlinable
-    func sendLocationNotification(
+    public func sendLocationNotification(
         _ notification: APNSLocationNotification,
         deviceToken: String
     ) async throws -> APNSResponse {


### PR DESCRIPTION
Marked sendLocationNotification public to be accessible outside of APNSCore