### PR TITLE
Make APNSClient Sendable if coders are Sendable

### DIFF
--- a/Sources/APNS/APNSClient.swift
+++ b/Sources/APNS/APNSClient.swift
@@ -135,6 +135,7 @@ public final class APNSClient<Decoder: APNSJSONDecoder, Encoder: APNSJSONEncoder
     }
 }
 
+extension APNSClient: Sendable where Decoder: Sendable, Encoder: Sendable {}
 
 // MARK: - Raw sending
 


### PR DESCRIPTION
`JSONEncoder` and `JSONDecoder` also conform to `Sendable`, making the most commonly used `APNSClient` then `Sendable` as well.