### PR TITLE
Add ability to start live activities

### DIFF
--- a/Sources/APNSCore/Alert/APNSAlertNotificationContent.swift
+++ b/Sources/APNSCore/Alert/APNSAlertNotificationContent.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// The information for displaying an alert.
-public struct APNSAlertNotificationContent: Encodable, Sendable {
+public struct APNSAlertNotificationContent: Encodable, Sendable, Hashable {
     public struct StringValue: Encodable, Hashable, Sendable {
         internal enum Configuration: Encodable, Hashable {
             case raw(String)

--- a/Sources/APNSCore/Alert/APNSAlertNotificationContent.swift
+++ b/Sources/APNSCore/Alert/APNSAlertNotificationContent.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// The information for displaying an alert.
-public struct APNSAlertNotificationContent: Encodable, Sendable, Hashable {
+public struct APNSAlertNotificationContent: Encodable, Sendable {
     public struct StringValue: Encodable, Hashable, Sendable {
         internal enum Configuration: Encodable, Hashable {
             case raw(String)

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
@@ -38,6 +38,16 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Hashable & 
         }
     }
 
+    public var alert: APNSAlertNotificationContent? {
+        get {
+            return self.aps.alert
+        }
+
+        set {
+            self.aps.alert = newValue
+        }
+    }
+
     /// Event type e.g. update
     public var event: any APNSLiveActivityNotificationEvent {
         get {
@@ -48,14 +58,17 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Hashable & 
                 return APNSLiveActivityNotificationEventUpdate()
             default:
                 guard let attributesType = self.aps.attributesType,
-                    let state = self.aps.attributesContent
+                    let state = self.aps.attributesContent,
+                    let alert = self.aps.alert
                 else {
                     // Default to update
                     return APNSLiveActivityNotificationEventUpdate()
                 }
 
                 return APNSLiveActivityNotificationEventStart(
-                    attributes: .init(type: attributesType, state: state))
+                    attributes: .init(type: attributesType, state: state),
+                    alert: alert
+                )
             }
         }
 
@@ -173,8 +186,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Hashable & 
 
         self.aps = APNSLiveActivityNotificationAPSStorage(
             timestamp: timestamp,
-            event: event.rawValue,
-            attributes: attributes,
+            event: event,
             contentState: contentState,
             dismissalDate: dismissalDate.dismissal
         )

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
@@ -12,13 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct Foundation.UUID
 import struct Foundation.Data
+import struct Foundation.UUID
 
 /// A live activity notification.
 ///
 /// It is **important** that you do not encode anything with the key `aps`.
-public struct APNSLiveActivityNotification<ContentState: Encodable & Hashable & Sendable>: APNSMessage {
+public struct APNSLiveActivityNotification<ContentState: Encodable & Hashable & Sendable>:
+    APNSMessage
+{
     enum CodingKeys: CodingKey {
         case aps
     }
@@ -31,30 +33,33 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Hashable & 
         get {
             return self.aps.timestamp
         }
-        
+
         set {
             self.aps.timestamp = newValue
         }
     }
-    
+
     /// Event type e.g. update
     public var event: any APNSLiveActivityNotificationEvent {
         get {
-					switch self.aps.event {
-					case "end":
-						return APNSLiveActivityNotificationEventEnd()
-					case "update":
-						return APNSLiveActivityNotificationEventUpdate()
-					default:
-						guard let attributesType = self.aps.attributesType, let state = self.aps.attributesContent else {
-							// Default to update
-							return APNSLiveActivityNotificationEventUpdate()
-						}
+            switch self.aps.event {
+            case "end":
+                return APNSLiveActivityNotificationEventEnd()
+            case "update":
+                return APNSLiveActivityNotificationEventUpdate()
+            default:
+                guard let attributesType = self.aps.attributesType,
+                    let state = self.aps.attributesContent
+                else {
+                    // Default to update
+                    return APNSLiveActivityNotificationEventUpdate()
+                }
 
-						return APNSLiveActivityNotificationEventStart(attributes: .init(type: attributesType, state: state))
-					}
+                return APNSLiveActivityNotificationEventStart(
+                    attributes: .init(type: attributesType, state: state))
+            }
         }
-        
+
         set {
             self.aps.event = newValue.rawValue
         }
@@ -65,7 +70,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Hashable & 
         get {
             return self.aps.contentState
         }
-        
+
         set {
             self.aps.contentState = newValue
         }
@@ -79,7 +84,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Hashable & 
             self.aps.dismissalDate = newValue?.dismissal
         }
     }
-    
+
     /// A canonical UUID that identifies the notification. If there is an error sending the notification,
     /// APNs uses this value to identify the notification to your server. The canonical form is 32 lowercase hexadecimal digits,
     /// displayed in five groups separated by hyphens in the form 8-4-4-4-12. An example UUID is as follows:
@@ -136,7 +141,6 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Hashable & 
             dismissalDate: dismissalDate
         )
     }
-    
 
     /// Initializes a new ``APNSLiveActivityNotification``.
     ///
@@ -163,15 +167,15 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Hashable & 
         timestamp: Int,
         dismissalDate: APNSLiveActivityDismissalDate = .none
     ) {
-				var attributes: APNSLiveActivityNotificationEventStart<ContentState>.Attributes?
-				if let event = event as? APNSLiveActivityNotificationEventStart<ContentState> {
-					attributes = event.attributes
-				}
+        var attributes: APNSLiveActivityNotificationEventStart<ContentState>.Attributes?
+        if let event = event as? APNSLiveActivityNotificationEventStart<ContentState> {
+            attributes = event.attributes
+        }
 
         self.aps = APNSLiveActivityNotificationAPSStorage(
             timestamp: timestamp,
             event: event.rawValue,
-						attributes: attributes,
+            attributes: attributes,
             contentState: contentState,
             dismissalDate: dismissalDate.dismissal
         )

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
@@ -17,7 +17,7 @@ import struct Foundation.UUID
 /// A live activity notification.
 ///
 /// It is **important** that you do not encode anything with the key `aps`.
-public struct APNSLiveActivityNotification<ContentState: Encodable & Hashable & Sendable>:
+public struct APNSLiveActivityNotification<ContentState: Encodable>:
     APNSMessage
 {
     enum CodingKeys: CodingKey {
@@ -49,7 +49,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Hashable & 
     }
 
     /// Event type e.g. update
-    public var event: any APNSLiveActivityNotificationEvent {
+    public var event: APNSLiveActivityNotificationEvent {
         get {
             switch self.aps.event {
             case "end":

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
@@ -17,9 +17,7 @@ import struct Foundation.UUID
 /// A live activity notification.
 ///
 /// It is **important** that you do not encode anything with the key `aps`.
-public struct APNSLiveActivityNotification<ContentState: Encodable>:
-    APNSMessage
-{
+public struct APNSLiveActivityNotification<ContentState: Encodable>: APNSMessage {
     enum CodingKeys: CodingKey {
         case aps
     }

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct Foundation.Data
 import struct Foundation.UUID
 
 /// A live activity notification.

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
@@ -49,7 +49,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable>: APNSMessage
     /// Event type e.g. update
     public var event: APNSLiveActivityNotificationEvent {
         get {
-						return APNSLiveActivityNotificationEvent(rawValue: self.aps.event)
+            return APNSLiveActivityNotificationEvent(rawValue: self.aps.event)
         }
 
         set {
@@ -119,7 +119,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable>: APNSMessage
         appID: String,
         contentState: ContentState,
         event: APNSLiveActivityNotificationEvent,
-				startOptions: APNSLiveActivityNotificationEventStartOptions<ContentState>? = nil,
+        startOptions: APNSLiveActivityNotificationEventStartOptions<ContentState>? = nil,
         timestamp: Int,
         dismissalDate: APNSLiveActivityDismissalDate = .none,
         apnsID: UUID? = nil
@@ -130,7 +130,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable>: APNSMessage
             topic: appID + ".push-type.liveactivity",
             contentState: contentState,
             event: event,
-						startOptions: startOptions,
+            startOptions: startOptions,
             timestamp: timestamp,
             dismissalDate: dismissalDate
         )
@@ -158,14 +158,14 @@ public struct APNSLiveActivityNotification<ContentState: Encodable>: APNSMessage
         apnsID: UUID? = nil,
         contentState: ContentState,
         event: APNSLiveActivityNotificationEvent,
-				startOptions: APNSLiveActivityNotificationEventStartOptions<ContentState>? = nil,
+        startOptions: APNSLiveActivityNotificationEventStartOptions<ContentState>? = nil,
         timestamp: Int,
         dismissalDate: APNSLiveActivityDismissalDate = .none
     ) {
         self.aps = APNSLiveActivityNotificationAPSStorage(
             timestamp: timestamp,
             event: event,
-						startOptions: startOptions,
+            startOptions: startOptions,
             contentState: contentState,
             dismissalDate: dismissalDate.dismissal
         )

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
@@ -151,7 +151,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable>: APNSMessage
     ) {
         self.aps = APNSLiveActivityNotificationAPSStorage(
             timestamp: timestamp,
-            event: event,
+						event: event.rawValue,
             contentState: contentState,
             dismissalDate: dismissalDate.dismissal
         )

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
@@ -151,7 +151,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable>: APNSMessage
     ) {
         self.aps = APNSLiveActivityNotificationAPSStorage(
             timestamp: timestamp,
-						event: event.rawValue,
+            event: event.rawValue,
             contentState: contentState,
             dismissalDate: dismissalDate.dismissal
         )

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
@@ -49,25 +49,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable>: APNSMessage
     /// Event type e.g. update
     public var event: APNSLiveActivityNotificationEvent {
         get {
-            switch self.aps.event {
-            case "end":
-                return APNSLiveActivityNotificationEventEnd()
-            case "update":
-                return APNSLiveActivityNotificationEventUpdate()
-            default:
-                guard let attributesType = self.aps.attributesType,
-                    let state = self.aps.attributesContent,
-                    let alert = self.aps.alert
-                else {
-                    // Default to update
-                    return APNSLiveActivityNotificationEventUpdate()
-                }
-
-                return APNSLiveActivityNotificationEventStart(
-                    attributes: .init(type: attributesType, state: state),
-                    alert: alert
-                )
-            }
+						return APNSLiveActivityNotificationEvent(rawValue: self.aps.event)
         }
 
         set {
@@ -136,7 +118,8 @@ public struct APNSLiveActivityNotification<ContentState: Encodable>: APNSMessage
         priority: APNSPriority,
         appID: String,
         contentState: ContentState,
-        event: any APNSLiveActivityNotificationEvent,
+        event: APNSLiveActivityNotificationEvent,
+				startOptions: APNSLiveActivityNotificationEventStartOptions<ContentState>? = nil,
         timestamp: Int,
         dismissalDate: APNSLiveActivityDismissalDate = .none,
         apnsID: UUID? = nil
@@ -147,6 +130,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable>: APNSMessage
             topic: appID + ".push-type.liveactivity",
             contentState: contentState,
             event: event,
+						startOptions: startOptions,
             timestamp: timestamp,
             dismissalDate: dismissalDate
         )
@@ -173,18 +157,15 @@ public struct APNSLiveActivityNotification<ContentState: Encodable>: APNSMessage
         topic: String,
         apnsID: UUID? = nil,
         contentState: ContentState,
-        event: any APNSLiveActivityNotificationEvent,
+        event: APNSLiveActivityNotificationEvent,
+				startOptions: APNSLiveActivityNotificationEventStartOptions<ContentState>? = nil,
         timestamp: Int,
         dismissalDate: APNSLiveActivityDismissalDate = .none
     ) {
-        var attributes: APNSLiveActivityNotificationEventStart<ContentState>.Attributes?
-        if let event = event as? APNSLiveActivityNotificationEventStart<ContentState> {
-            attributes = event.attributes
-        }
-
         self.aps = APNSLiveActivityNotificationAPSStorage(
             timestamp: timestamp,
             event: event,
+						startOptions: startOptions,
             contentState: contentState,
             dismissalDate: dismissalDate.dismissal
         )

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
@@ -27,13 +27,13 @@ struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable>: Encodabl
 
     init(
         timestamp: Int,
-        event: APNSLiveActivityNotificationEvent,
+        event: String,
         contentState: ContentState,
         dismissalDate: Int?
     ) {
         self.timestamp = timestamp
         self.contentState = contentState
         self.dismissalDate = dismissalDate
-        self.event = event.rawValue
+        self.event = event
     }
 }

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
@@ -11,28 +11,36 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+import struct Foundation.Data
 
-struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable>: Encodable {
+struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable & Hashable & Sendable>: Encodable, Sendable, Hashable {
     enum CodingKeys: String, CodingKey {
         case timestamp = "timestamp"
         case event = "event"
         case contentState = "content-state"
         case dismissalDate = "dismissal-date"
+				case attributesType = "attributes-type"
+				case attributesContent = "attributes"
     }
 
     var timestamp: Int
     var event: String
+		var attributesType: String?
+		var attributesContent: ContentState?
     var contentState: ContentState
     var dismissalDate: Int?
     
     init(
         timestamp: Int,
         event: String,
+				attributes: APNSLiveActivityNotificationEventStart<ContentState>.Attributes?,
         contentState: ContentState,
         dismissalDate: Int?
     ) {
         self.timestamp = timestamp
         self.event = event
+				self.attributesType = attributes?.type
+				self.attributesContent = attributes?.state
         self.contentState = contentState
         self.dismissalDate = dismissalDate
     }

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
@@ -34,7 +34,7 @@ struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable>: Encodabl
     init(
         timestamp: Int,
         event: APNSLiveActivityNotificationEvent,
-				startOptions: APNSLiveActivityNotificationEventStartOptions<ContentState>?,
+        startOptions: APNSLiveActivityNotificationEventStartOptions<ContentState>?,
         contentState: ContentState,
         dismissalDate: Int?
     ) {
@@ -43,10 +43,10 @@ struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable>: Encodabl
         self.dismissalDate = dismissalDate
         self.event = event.rawValue
 
-				if let startOptions {
-					self.attributesType = startOptions.attributeType
-					self.attributesContent = startOptions.attributes
-					self.alert = startOptions.alert
+        if let startOptions {
+            self.attributesType = startOptions.attributeType
+            self.attributesContent = startOptions.attributes
+            self.alert = startOptions.alert
         }
     }
 }

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
@@ -12,9 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable & Hashable & Sendable>:
-    Encodable, Sendable, Hashable
-{
+struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable>: Encodable {
     enum CodingKeys: String, CodingKey {
         case timestamp = "timestamp"
         case event = "event"

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
@@ -11,7 +11,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import struct Foundation.Data
 
 struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable & Hashable & Sendable>:
     Encodable, Sendable, Hashable

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
@@ -13,34 +13,36 @@
 //===----------------------------------------------------------------------===//
 import struct Foundation.Data
 
-struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable & Hashable & Sendable>: Encodable, Sendable, Hashable {
+struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable & Hashable & Sendable>:
+    Encodable, Sendable, Hashable
+{
     enum CodingKeys: String, CodingKey {
         case timestamp = "timestamp"
         case event = "event"
         case contentState = "content-state"
         case dismissalDate = "dismissal-date"
-				case attributesType = "attributes-type"
-				case attributesContent = "attributes"
+        case attributesType = "attributes-type"
+        case attributesContent = "attributes"
     }
 
     var timestamp: Int
     var event: String
-		var attributesType: String?
-		var attributesContent: ContentState?
+    var attributesType: String?
+    var attributesContent: ContentState?
     var contentState: ContentState
     var dismissalDate: Int?
-    
+
     init(
         timestamp: Int,
         event: String,
-				attributes: APNSLiveActivityNotificationEventStart<ContentState>.Attributes?,
+        attributes: APNSLiveActivityNotificationEventStart<ContentState>.Attributes?,
         contentState: ContentState,
         dismissalDate: Int?
     ) {
         self.timestamp = timestamp
         self.event = event
-				self.attributesType = attributes?.type
-				self.attributesContent = attributes?.state
+        self.attributesType = attributes?.type
+        self.attributesContent = attributes?.state
         self.contentState = contentState
         self.dismissalDate = dismissalDate
     }

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
@@ -22,6 +22,7 @@ struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable & Hashable
         case dismissalDate = "dismissal-date"
         case attributesType = "attributes-type"
         case attributesContent = "attributes"
+        case alert = "alert"
     }
 
     var timestamp: Int
@@ -30,19 +31,23 @@ struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable & Hashable
     var attributesContent: ContentState?
     var contentState: ContentState
     var dismissalDate: Int?
+    var alert: APNSAlertNotificationContent?
 
     init(
         timestamp: Int,
-        event: String,
-        attributes: APNSLiveActivityNotificationEventStart<ContentState>.Attributes?,
+        event: any APNSLiveActivityNotificationEvent,
         contentState: ContentState,
         dismissalDate: Int?
     ) {
         self.timestamp = timestamp
-        self.event = event
-        self.attributesType = attributes?.type
-        self.attributesContent = attributes?.state
         self.contentState = contentState
         self.dismissalDate = dismissalDate
+        self.event = event.rawValue
+
+        if let event = event as? APNSLiveActivityNotificationEventStart<ContentState> {
+            self.attributesType = event.attributes.type
+            self.attributesContent = event.attributes.state
+            self.alert = event.alert
+        }
     }
 }

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
@@ -33,7 +33,8 @@ struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable>: Encodabl
 
     init(
         timestamp: Int,
-        event: any APNSLiveActivityNotificationEvent,
+        event: APNSLiveActivityNotificationEvent,
+				startOptions: APNSLiveActivityNotificationEventStartOptions<ContentState>?,
         contentState: ContentState,
         dismissalDate: Int?
     ) {
@@ -42,10 +43,10 @@ struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable>: Encodabl
         self.dismissalDate = dismissalDate
         self.event = event.rawValue
 
-        if let event = event as? APNSLiveActivityNotificationEventStart<ContentState> {
-            self.attributesType = event.attributes.type
-            self.attributesContent = event.attributes.state
-            self.alert = event.alert
+				if let startOptions {
+					self.attributesType = startOptions.attributeType
+					self.attributesContent = startOptions.attributes
+					self.alert = startOptions.alert
         }
     }
 }

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
@@ -22,7 +22,4 @@ public struct APNSLiveActivityNotificationEvent: Hashable {
 
     /// Specifies that live activity should be ended
     public static let end = Self(rawValue: "end")
-
-    /// The underlying raw value that is send to APNs.
-    public static let start = Self(rawValue: "start")
 }

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 public struct APNSLiveActivityNotificationEvent: Hashable {
-    
     /// The underlying raw value that is send to APNs.
     @usableFromInline
     internal let rawValue: String
@@ -23,4 +22,6 @@ public struct APNSLiveActivityNotificationEvent: Hashable {
     
     /// Specifies that live activity should be ended
     public static let end = Self(rawValue: "end")
+
+		public static let start = Self(rawValue: "start")
 }

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
@@ -12,65 +12,30 @@
 //
 //===----------------------------------------------------------------------===//
 
-public protocol APNSLiveActivityNotificationEvent: Encodable {
-    var rawValue: String { get }
+
+public struct APNSLiveActivityNotificationEvent: Encodable {
+			/// The underlying raw value that is send to APNs.
+			@usableFromInline
+			internal let rawValue: String
+
+			/// Specifies that live activity should be updated
+			public static let update = Self(rawValue: "update")
+
+			/// Specifies that live activity should be ended
+			public static let end = Self(rawValue: "end")
+
+			/// The underlying raw value that is send to APNs.
+			public static let start = Self(rawValue: "start")
 }
 
-public struct APNSLiveActivityNotificationEventUpdate: APNSLiveActivityNotificationEvent {
-    public let rawValue = "update"
-}
+public struct APNSLiveActivityNotificationEventStartOptions<State: Encodable> {
+	var attributeType: String
+	var attributes: State
+	var alert: APNSAlertNotificationContent
 
-public struct APNSLiveActivityNotificationEventEnd: APNSLiveActivityNotificationEvent {
-    public let rawValue = "end"
-}
-
-public protocol APNSLiveActivityNotificationEventStartStateProtocol: Encodable
-{
-    associatedtype State: Encodable
-}
-
-public struct APNSLiveActivityNotificationEventStart<State: Encodable>:
-    APNSLiveActivityNotificationEvent, APNSLiveActivityNotificationEventStartStateProtocol
-{
-    public struct Attributes: Encodable {
-        public let type: String
-        public let state: State
-
-        public init(type: String, state: State) {
-            self.type = type
-            self.state = state
-        }
-    }
-
-    public let rawValue = "start"
-    public let attributes: Attributes
-    public let alert: APNSAlertNotificationContent
-
-    public init(attributes: Attributes, alert: APNSAlertNotificationContent) {
-        self.attributes = attributes
-        self.alert = alert
-    }
-}
-
-extension APNSLiveActivityNotificationEvent where Self == APNSLiveActivityNotificationEventUpdate {
-    public static var update: APNSLiveActivityNotificationEventUpdate {
-        APNSLiveActivityNotificationEventUpdate()
-    }
-}
-
-extension APNSLiveActivityNotificationEvent where Self == APNSLiveActivityNotificationEventEnd {
-    public static var end: APNSLiveActivityNotificationEventEnd {
-        APNSLiveActivityNotificationEventEnd()
-    }
-}
-
-extension APNSLiveActivityNotificationEvent
-where Self: APNSLiveActivityNotificationEventStartStateProtocol {
-    public static func start(type: String, state: State, alert: APNSAlertNotificationContent)
-        -> APNSLiveActivityNotificationEventStart<
-            State
-        >
-    {
-        .init(attributes: .init(type: type, state: state), alert: alert)
-    }
+	public init(attributeType: String, attributes: State, alert: APNSAlertNotificationContent) {
+		self.attributeType = attributeType
+		self.attributes = attributes
+		self.alert = alert
+	}
 }

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
@@ -12,30 +12,29 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 public struct APNSLiveActivityNotificationEvent: Encodable {
-			/// The underlying raw value that is send to APNs.
-			@usableFromInline
-			internal let rawValue: String
+    /// The underlying raw value that is send to APNs.
+    @usableFromInline
+    internal let rawValue: String
 
-			/// Specifies that live activity should be updated
-			public static let update = Self(rawValue: "update")
+    /// Specifies that live activity should be updated
+    public static let update = Self(rawValue: "update")
 
-			/// Specifies that live activity should be ended
-			public static let end = Self(rawValue: "end")
+    /// Specifies that live activity should be ended
+    public static let end = Self(rawValue: "end")
 
-			/// The underlying raw value that is send to APNs.
-			public static let start = Self(rawValue: "start")
+    /// The underlying raw value that is send to APNs.
+    public static let start = Self(rawValue: "start")
 }
 
 public struct APNSLiveActivityNotificationEventStartOptions<State: Encodable> {
-	var attributeType: String
-	var attributes: State
-	var alert: APNSAlertNotificationContent
+    var attributeType: String
+    var attributes: State
+    var alert: APNSAlertNotificationContent
 
-	public init(attributeType: String, attributes: State, alert: APNSAlertNotificationContent) {
-		self.attributeType = attributeType
-		self.attributes = attributes
-		self.alert = alert
-	}
+    public init(attributeType: String, attributes: State, alert: APNSAlertNotificationContent) {
+        self.attributeType = attributeType
+        self.attributes = attributes
+        self.alert = alert
+    }
 }

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public protocol APNSLiveActivityNotificationEvent: Hashable, Encodable {
+public protocol APNSLiveActivityNotificationEvent: Encodable {
     var rawValue: String { get }
 }
 
@@ -24,15 +24,15 @@ public struct APNSLiveActivityNotificationEventEnd: APNSLiveActivityNotification
     public let rawValue = "end"
 }
 
-public protocol APNSLiveActivityNotificationEventStartStateProtocol: Encodable & Hashable & Sendable
+public protocol APNSLiveActivityNotificationEventStartStateProtocol: Encodable
 {
-    associatedtype State: Encodable & Hashable & Sendable
+    associatedtype State: Encodable
 }
 
-public struct APNSLiveActivityNotificationEventStart<State: Encodable & Hashable & Sendable>:
+public struct APNSLiveActivityNotificationEventStart<State: Encodable>:
     APNSLiveActivityNotificationEvent, APNSLiveActivityNotificationEventStartStateProtocol
 {
-    public struct Attributes: Encodable, Hashable, Sendable {
+    public struct Attributes: Encodable {
         public let type: String
         public let state: State
 

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
@@ -13,50 +13,60 @@
 //===----------------------------------------------------------------------===//
 
 public protocol APNSLiveActivityNotificationEvent: Hashable, Encodable {
-	var rawValue: String { get }
+    var rawValue: String { get }
 }
 
 public struct APNSLiveActivityNotificationEventUpdate: APNSLiveActivityNotificationEvent {
-	public let rawValue = "update"
+    public let rawValue = "update"
 }
 
 public struct APNSLiveActivityNotificationEventEnd: APNSLiveActivityNotificationEvent {
-	public let rawValue = "end"
+    public let rawValue = "end"
 }
 
-public protocol APNSLiveActivityNotificationEventStartStateProtocol: Encodable & Hashable & Sendable {
-	associatedtype State: Encodable & Hashable & Sendable
+public protocol APNSLiveActivityNotificationEventStartStateProtocol: Encodable & Hashable & Sendable
+{
+    associatedtype State: Encodable & Hashable & Sendable
 }
 
-public struct APNSLiveActivityNotificationEventStart<State: Encodable & Hashable & Sendable>: APNSLiveActivityNotificationEvent, APNSLiveActivityNotificationEventStartStateProtocol {
-	public struct Attributes: Encodable, Hashable, Sendable {
-		public let type: String
-		public let state: State
+public struct APNSLiveActivityNotificationEventStart<State: Encodable & Hashable & Sendable>:
+    APNSLiveActivityNotificationEvent, APNSLiveActivityNotificationEventStartStateProtocol
+{
+    public struct Attributes: Encodable, Hashable, Sendable {
+        public let type: String
+        public let state: State
 
-		public init(type: String, state: State) {
-			self.type = type
-			self.state = state
-		}
-	}
+        public init(type: String, state: State) {
+            self.type = type
+            self.state = state
+        }
+    }
 
-	public let rawValue = "start"
-	public let attributes: Attributes
+    public let rawValue = "start"
+    public let attributes: Attributes
 
-	public init(attributes: Attributes) {
-		self.attributes = attributes
-	}
+    public init(attributes: Attributes) {
+        self.attributes = attributes
+    }
 }
 
-public extension APNSLiveActivityNotificationEvent where Self == APNSLiveActivityNotificationEventUpdate {
-	static var update: APNSLiveActivityNotificationEventUpdate { APNSLiveActivityNotificationEventUpdate() }
+extension APNSLiveActivityNotificationEvent where Self == APNSLiveActivityNotificationEventUpdate {
+    public static var update: APNSLiveActivityNotificationEventUpdate {
+        APNSLiveActivityNotificationEventUpdate()
+    }
 }
 
-public extension APNSLiveActivityNotificationEvent where Self == APNSLiveActivityNotificationEventEnd {
-	static var end: APNSLiveActivityNotificationEventEnd { APNSLiveActivityNotificationEventEnd() }
+extension APNSLiveActivityNotificationEvent where Self == APNSLiveActivityNotificationEventEnd {
+    public static var end: APNSLiveActivityNotificationEventEnd {
+        APNSLiveActivityNotificationEventEnd()
+    }
 }
 
-public extension APNSLiveActivityNotificationEvent where Self: APNSLiveActivityNotificationEventStartStateProtocol {
-	static func start(type: String, state: State) -> APNSLiveActivityNotificationEventStart<State> {
-		.init(attributes: .init(type: type, state: state))
-	}
+extension APNSLiveActivityNotificationEvent
+where Self: APNSLiveActivityNotificationEventStartStateProtocol {
+    public static func start(type: String, state: State) -> APNSLiveActivityNotificationEventStart<
+        State
+    > {
+        .init(attributes: .init(type: type, state: state))
+    }
 }

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
@@ -44,9 +44,11 @@ public struct APNSLiveActivityNotificationEventStart<State: Encodable & Hashable
 
     public let rawValue = "start"
     public let attributes: Attributes
+    public let alert: APNSAlertNotificationContent
 
-    public init(attributes: Attributes) {
+    public init(attributes: Attributes, alert: APNSAlertNotificationContent) {
         self.attributes = attributes
+        self.alert = alert
     }
 }
 
@@ -64,9 +66,11 @@ extension APNSLiveActivityNotificationEvent where Self == APNSLiveActivityNotifi
 
 extension APNSLiveActivityNotificationEvent
 where Self: APNSLiveActivityNotificationEventStartStateProtocol {
-    public static func start(type: String, state: State) -> APNSLiveActivityNotificationEventStart<
-        State
-    > {
-        .init(attributes: .init(type: type, state: state))
+    public static func start(type: String, state: State, alert: APNSAlertNotificationContent)
+        -> APNSLiveActivityNotificationEventStart<
+            State
+        >
+    {
+        .init(attributes: .init(type: type, state: state), alert: alert)
     }
 }

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct APNSLiveActivityNotificationEvent: Encodable {
+public struct APNSLiveActivityNotificationEvent: Hashable {
     /// The underlying raw value that is send to APNs.
     @usableFromInline
     internal let rawValue: String

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
@@ -26,15 +26,3 @@ public struct APNSLiveActivityNotificationEvent: Hashable {
     /// The underlying raw value that is send to APNs.
     public static let start = Self(rawValue: "start")
 }
-
-public struct APNSLiveActivityNotificationEventStartOptions<State: Encodable> {
-    var attributeType: String
-    var attributes: State
-    var alert: APNSAlertNotificationContent
-
-    public init(attributeType: String, attributes: State, alert: APNSAlertNotificationContent) {
-        self.attributeType = attributeType
-        self.attributes = attributes
-        self.alert = alert
-    }
-}

--- a/Sources/APNSCore/LiveActivity/APNSStartLiveActivityNotification.swift
+++ b/Sources/APNSCore/LiveActivity/APNSStartLiveActivityNotification.swift
@@ -14,16 +14,18 @@
 
 import struct Foundation.UUID
 
-/// A live activity notification.
+/// A notification that starts a live activity
 ///
 /// It is **important** that you do not encode anything with the key `aps`.
-public struct APNSLiveActivityNotification<ContentState: Encodable>: APNSMessage {
+public struct APNSStartLiveActivityNotification<Attributes: Encodable, ContentState: Encodable>:
+    APNSMessage
+{
     enum CodingKeys: CodingKey {
         case aps
     }
 
     /// The fixed content to indicate that this is a background notification.
-    private var aps: APNSLiveActivityNotificationAPSStorage<ContentState>
+    private var aps: APNSStartLiveActivityNotificationAPSStorage<Attributes, ContentState>
 
     /// Timestamp when sending notification
     public var timestamp: Int {
@@ -36,14 +38,13 @@ public struct APNSLiveActivityNotification<ContentState: Encodable>: APNSMessage
         }
     }
 
-    /// Event type e.g. update
-    public var event: APNSLiveActivityNotificationEvent {
+    public var alert: APNSAlertNotificationContent {
         get {
-            return APNSLiveActivityNotificationEvent(rawValue: self.aps.event)
+            return self.aps.alert
         }
 
         set {
-            self.aps.event = newValue.rawValue
+            self.aps.alert = newValue
         }
     }
 
@@ -88,7 +89,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable>: APNSMessage
     /// The topic for the notification. In general, the topic is your app’s bundle ID/app ID.
     public var topic: String
 
-    /// Initializes a new ``APNSLiveActivityNotification``.
+    /// Initializes a new ``APNSStartLiveActivityNotification``.
     ///
     /// - Important: Your dynamic payload will get encoded to the root of the JSON payload that is send to APNs.
     /// It is **important** that you do not encode anything with the key `aps`
@@ -99,32 +100,38 @@ public struct APNSLiveActivityNotification<ContentState: Encodable>: APNSMessage
     ///   - appID: Your app’s bundle ID/app ID. This will be suffixed with `.push-type.liveactivity`.
     ///   - apnsID: A canonical UUID that identifies the notification.
     ///   - contentState: Updated content-state of live activity
-    ///   - event: event type e.g. update
     ///   - timestamp: Timestamp when sending notification
     ///   - dismissalDate: Timestamp when to dismiss live notification when sent with `end`, if in the past
     ///    dismiss immediately
+    ///   - attributes: The ActivityAttributes of the live activity to start
+    ///   - attributesString: The type name of the ActivityAttributes you want to send
+    ///   - alert: An alert that will be sent along with the notification
     public init(
         expiration: APNSNotificationExpiration,
         priority: APNSPriority,
         appID: String,
         contentState: ContentState,
-        event: APNSLiveActivityNotificationEvent,
         timestamp: Int,
         dismissalDate: APNSLiveActivityDismissalDate = .none,
-        apnsID: UUID? = nil
+        apnsID: UUID? = nil,
+        attributes: Attributes,
+        attributesType: String,
+        alert: APNSAlertNotificationContent
     ) {
         self.init(
             expiration: expiration,
             priority: priority,
             topic: appID + ".push-type.liveactivity",
             contentState: contentState,
-            event: event,
             timestamp: timestamp,
-            dismissalDate: dismissalDate
+            dismissalDate: dismissalDate,
+            attributes: attributes,
+            attributesType: attributesType,
+            alert: alert
         )
     }
 
-    /// Initializes a new ``APNSLiveActivityNotification``.
+    /// Initializes a new ``APNSStartLiveActivityNotification``.
     ///
     /// - Important: Your dynamic payload will get encoded to the root of the JSON payload that is send to APNs.
     /// It is **important** that you do not encode anything with the key `aps`
@@ -135,25 +142,31 @@ public struct APNSLiveActivityNotification<ContentState: Encodable>: APNSMessage
     ///   - topic: The topic for the notification. In general, the topic is your app’s bundle ID/app ID suffixed with `.push-type.liveactivity`.
     ///   - apnsID: A canonical UUID that identifies the notification.
     ///   - contentState: Updated content-state of live activity
-    ///   - event: event type e.g. update
     ///   - timestamp: Timestamp when sending notification
     ///   - dismissalDate: Timestamp when to dismiss live notification when sent with `end`, if in the past
     ///    dismiss immediately
+    ///   - attributes: The ActivityAttributes of the live activity to start
+    ///   - attributesString: The type name of the ActivityAttributes you want to send
+    ///   - alert: An alert that will be sent along with the notification
     public init(
         expiration: APNSNotificationExpiration,
         priority: APNSPriority,
         topic: String,
         apnsID: UUID? = nil,
         contentState: ContentState,
-        event: APNSLiveActivityNotificationEvent,
         timestamp: Int,
-        dismissalDate: APNSLiveActivityDismissalDate = .none
+        dismissalDate: APNSLiveActivityDismissalDate = .none,
+        attributes: Attributes,
+        attributesType: String,
+        alert: APNSAlertNotificationContent
     ) {
-        self.aps = APNSLiveActivityNotificationAPSStorage(
+        self.aps = APNSStartLiveActivityNotificationAPSStorage(
             timestamp: timestamp,
-            event: event,
             contentState: contentState,
-            dismissalDate: dismissalDate.dismissal
+            dismissalDate: dismissalDate.dismissal,
+            alert: alert,
+            attributes: attributes,
+            attributesType: attributesType
         )
         self.apnsID = apnsID
         self.expiration = expiration

--- a/Sources/APNSCore/LiveActivity/APNSStartLiveActivityNotification.swift
+++ b/Sources/APNSCore/LiveActivity/APNSStartLiveActivityNotification.swift
@@ -98,13 +98,13 @@ public struct APNSStartLiveActivityNotification<Attributes: Encodable, ContentSt
     ///   - expiration: The date when the notification is no longer valid and can be discarded.
     ///   - priority: The priority of the notification.
     ///   - appID: Your app’s bundle ID/app ID. This will be suffixed with `.push-type.liveactivity`.
-    ///   - apnsID: A canonical UUID that identifies the notification.
     ///   - contentState: Updated content-state of live activity
     ///   - timestamp: Timestamp when sending notification
     ///   - dismissalDate: Timestamp when to dismiss live notification when sent with `end`, if in the past
     ///    dismiss immediately
+    ///   - apnsID: A canonical UUID that identifies the notification.
     ///   - attributes: The ActivityAttributes of the live activity to start
-    ///   - attributesString: The type name of the ActivityAttributes you want to send
+    ///   - attributesType: The type name of the ActivityAttributes you want to send
     ///   - alert: An alert that will be sent along with the notification
     public init(
         expiration: APNSNotificationExpiration,
@@ -118,59 +118,17 @@ public struct APNSStartLiveActivityNotification<Attributes: Encodable, ContentSt
         attributesType: String,
         alert: APNSAlertNotificationContent
     ) {
-        self.init(
-            expiration: expiration,
-            priority: priority,
-            topic: appID + ".push-type.liveactivity",
-            contentState: contentState,
-            timestamp: timestamp,
-            dismissalDate: dismissalDate,
-            attributes: attributes,
-            attributesType: attributesType,
-            alert: alert
-        )
-    }
-
-    /// Initializes a new ``APNSStartLiveActivityNotification``.
-    ///
-    /// - Important: Your dynamic payload will get encoded to the root of the JSON payload that is send to APNs.
-    /// It is **important** that you do not encode anything with the key `aps`
-    ///
-    /// - Parameters:
-    ///   - expiration: The date when the notification is no longer valid and can be discarded.
-    ///   - priority: The priority of the notification.
-    ///   - topic: The topic for the notification. In general, the topic is your app’s bundle ID/app ID suffixed with `.push-type.liveactivity`.
-    ///   - apnsID: A canonical UUID that identifies the notification.
-    ///   - contentState: Updated content-state of live activity
-    ///   - timestamp: Timestamp when sending notification
-    ///   - dismissalDate: Timestamp when to dismiss live notification when sent with `end`, if in the past
-    ///    dismiss immediately
-    ///   - attributes: The ActivityAttributes of the live activity to start
-    ///   - attributesString: The type name of the ActivityAttributes you want to send
-    ///   - alert: An alert that will be sent along with the notification
-    public init(
-        expiration: APNSNotificationExpiration,
-        priority: APNSPriority,
-        topic: String,
-        apnsID: UUID? = nil,
-        contentState: ContentState,
-        timestamp: Int,
-        dismissalDate: APNSLiveActivityDismissalDate = .none,
-        attributes: Attributes,
-        attributesType: String,
-        alert: APNSAlertNotificationContent
-    ) {
-        self.aps = APNSStartLiveActivityNotificationAPSStorage(
-            timestamp: timestamp,
-            contentState: contentState,
-            dismissalDate: dismissalDate.dismissal,
-            alert: alert,
-            attributes: attributes,
-            attributesType: attributesType
-        )
-        self.apnsID = apnsID
-        self.expiration = expiration
-        self.priority = priority
-        self.topic = topic
+      self.aps = APNSStartLiveActivityNotificationAPSStorage(
+          timestamp: timestamp,
+          contentState: contentState,
+          dismissalDate: dismissalDate.dismissal,
+          alert: alert,
+          attributes: attributes,
+          attributesType: attributesType
+			)
+			self.apnsID = apnsID
+			self.expiration = expiration
+			self.priority = priority
+			self.topic = appID + ".push-type.liveactivity"
     }
 }

--- a/Sources/APNSCore/LiveActivity/APNSStartLiveActivityNotificationAPSStorage.swift
+++ b/Sources/APNSCore/LiveActivity/APNSStartLiveActivityNotificationAPSStorage.swift
@@ -12,28 +12,40 @@
 //
 //===----------------------------------------------------------------------===//
 
-struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable>: Encodable {
+struct APNSStartLiveActivityNotificationAPSStorage<Attributes: Encodable, ContentState: Encodable>:
+    Encodable
+{
     enum CodingKeys: String, CodingKey {
         case timestamp = "timestamp"
         case event = "event"
         case contentState = "content-state"
         case dismissalDate = "dismissal-date"
+        case alert = "alert"
+        case attributes = "attributes"
+        case attributesType = "attributes-type"
     }
 
     var timestamp: Int
-    var event: String
+    var event: String = "start"
     var contentState: ContentState
     var dismissalDate: Int?
+    var alert: APNSAlertNotificationContent
+    var attributes: Attributes
+    var attributesType: String
 
     init(
         timestamp: Int,
-        event: APNSLiveActivityNotificationEvent,
         contentState: ContentState,
-        dismissalDate: Int?
+        dismissalDate: Int?,
+        alert: APNSAlertNotificationContent,
+        attributes: Attributes,
+        attributesType: String
     ) {
         self.timestamp = timestamp
         self.contentState = contentState
         self.dismissalDate = dismissalDate
-        self.event = event.rawValue
+        self.alert = alert
+        self.attributes = attributes
+        self.attributesType = attributesType
     }
 }

--- a/Tests/APNSTests/LiveActivity/APNSLiveActivityNotificationTests.swift
+++ b/Tests/APNSTests/LiveActivity/APNSLiveActivityNotificationTests.swift
@@ -53,14 +53,16 @@ final class APNSLiveActivityNotificationTests: XCTestCase {
             contentState: State(),
             // Need the fully qualified name here
             event: APNSLiveActivityNotificationEventStart(
-                attributes: .init(type: "State", state: State())),
+                attributes: .init(type: "State", state: State()),
+                alert: .init(title: .raw("Update"))
+            ),
             timestamp: 1_672_680_658)
 
         let encoder = JSONEncoder()
         let data = try encoder.encode(notification)
 
         let expectedJSONString = """
-            {"aps":{"event":"start", "attributes-type": "State", "attributes": {"string":"Test","number":123},"content-state":{"string":"Test","number":123},"timestamp":1672680658}}
+            {"aps":{"event":"start", "alert": { "title": "Update" }, "attributes-type": "State", "attributes": {"string":"Test","number":123},"content-state":{"string":"Test","number":123},"timestamp":1672680658}}
             """
 
         let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary

--- a/Tests/APNSTests/LiveActivity/APNSLiveActivityNotificationTests.swift
+++ b/Tests/APNSTests/LiveActivity/APNSLiveActivityNotificationTests.swift
@@ -51,8 +51,9 @@ final class APNSLiveActivityNotificationTests: XCTestCase {
             priority: .immediately,
             appID: "test.app.id",
             contentState: State(),
-						event: .start,
-						startOptions: .init(attributeType: "State", attributes: State(), alert: .init(title: .raw("Update"))),
+            event: .start,
+            startOptions: .init(
+                attributeType: "State", attributes: State(), alert: .init(title: .raw("Update"))),
             timestamp: 1_672_680_658)
 
         let encoder = JSONEncoder()

--- a/Tests/APNSTests/LiveActivity/APNSLiveActivityNotificationTests.swift
+++ b/Tests/APNSTests/LiveActivity/APNSLiveActivityNotificationTests.swift
@@ -51,11 +51,8 @@ final class APNSLiveActivityNotificationTests: XCTestCase {
             priority: .immediately,
             appID: "test.app.id",
             contentState: State(),
-            // Need the fully qualified name here
-            event: APNSLiveActivityNotificationEventStart(
-                attributes: .init(type: "State", state: State()),
-                alert: .init(title: .raw("Update"))
-            ),
+						event: .start,
+						startOptions: .init(attributeType: "State", attributes: State(), alert: .init(title: .raw("Update"))),
             timestamp: 1_672_680_658)
 
         let encoder = JSONEncoder()

--- a/Tests/APNSTests/LiveActivity/APNSLiveActivityNotificationTests.swift
+++ b/Tests/APNSTests/LiveActivity/APNSLiveActivityNotificationTests.swift
@@ -17,6 +17,10 @@ import XCTest
 
 final class APNSLiveActivityNotificationTests: XCTestCase {
 
+    struct Attributes: Encodable {
+        let name: String = "Test Attribute"
+    }
+
     struct State: Encodable, Hashable {
         let string: String = "Test"
         let number: Int = 123
@@ -46,21 +50,22 @@ final class APNSLiveActivityNotificationTests: XCTestCase {
     }
 
     func testEncodeStart() throws {
-        let notification = APNSLiveActivityNotification(
+        let notification = APNSStartLiveActivityNotification(
             expiration: .immediately,
             priority: .immediately,
             appID: "test.app.id",
             contentState: State(),
-            event: .start,
-            startOptions: .init(
-                attributeType: "State", attributes: State(), alert: .init(title: .raw("Update"))),
-            timestamp: 1_672_680_658)
+            timestamp: 1_672_680_658,
+            attributes: Attributes(),
+            attributesType: "Attributes",
+            alert: .init(title: .raw("Hi"), body: .raw("Hello"))
+        )
 
         let encoder = JSONEncoder()
         let data = try encoder.encode(notification)
 
         let expectedJSONString = """
-            {"aps":{"event":"start", "alert": { "title": "Update" }, "attributes-type": "State", "attributes": {"string":"Test","number":123},"content-state":{"string":"Test","number":123},"timestamp":1672680658}}
+            {"aps":{"event":"start", "alert": { "title": "Hi", "body": "Hello" }, "attributes-type": "Attributes", "attributes": {"name":"Test Attribute"},"content-state":{"string":"Test","number":123},"timestamp":1672680658}}
             """
 
         let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary

--- a/Tests/APNSTests/LiveActivity/APNSLiveActivityNotificationTests.swift
+++ b/Tests/APNSTests/LiveActivity/APNSLiveActivityNotificationTests.swift
@@ -42,7 +42,29 @@ final class APNSLiveActivityNotificationTests: XCTestCase {
         let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
         XCTAssertEqual(jsonObject1, jsonObject2)
     }
-    
+
+		func testEncodeStart() throws {
+				let notification = APNSLiveActivityNotification(
+						expiration: .immediately,
+						priority: .immediately,
+						appID: "test.app.id",
+						contentState: State(),
+						// Need the fully qualified name here
+						event: APNSLiveActivityNotificationEventStart(attributes: .init(type: "State", state: State())),
+						timestamp: 1672680658)
+
+				let encoder = JSONEncoder()
+				let data = try encoder.encode(notification)
+
+				let expectedJSONString = """
+				{"aps":{"event":"start", "attributes-type": "State", "attributes": {"string":"Test","number":123},"content-state":{"string":"Test","number":123},"timestamp":1672680658}}
+				"""
+
+				let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+				let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
+				XCTAssertEqual(jsonObject1, jsonObject2)
+		}
+
     func testEncodeEndNoDismiss() throws {
         let notification = APNSLiveActivityNotification(
             expiration: .immediately,

--- a/Tests/APNSTests/LiveActivity/APNSLiveActivityNotificationTests.swift
+++ b/Tests/APNSTests/LiveActivity/APNSLiveActivityNotificationTests.swift
@@ -21,7 +21,7 @@ final class APNSLiveActivityNotificationTests: XCTestCase {
         let string: String = "Test"
         let number: Int = 123
     }
-    
+
     func testEncodeUpdate() throws {
         let notification = APNSLiveActivityNotification(
             expiration: .immediately,
@@ -29,41 +29,46 @@ final class APNSLiveActivityNotificationTests: XCTestCase {
             appID: "test.app.id",
             contentState: State(),
             event: .update,
-            timestamp: 1672680658)
-        
+            timestamp: 1_672_680_658)
+
         let encoder = JSONEncoder()
         let data = try encoder.encode(notification)
 
         let expectedJSONString = """
-        {"aps":{"event":"update","content-state":{"string":"Test","number":123},"timestamp":1672680658}}
-        """
+            {"aps":{"event":"update","content-state":{"string":"Test","number":123},"timestamp":1672680658}}
+            """
 
         let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
-        let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
+        let jsonObject2 =
+            try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!)
+            as! NSDictionary
         XCTAssertEqual(jsonObject1, jsonObject2)
     }
 
-		func testEncodeStart() throws {
-				let notification = APNSLiveActivityNotification(
-						expiration: .immediately,
-						priority: .immediately,
-						appID: "test.app.id",
-						contentState: State(),
-						// Need the fully qualified name here
-						event: APNSLiveActivityNotificationEventStart(attributes: .init(type: "State", state: State())),
-						timestamp: 1672680658)
+    func testEncodeStart() throws {
+        let notification = APNSLiveActivityNotification(
+            expiration: .immediately,
+            priority: .immediately,
+            appID: "test.app.id",
+            contentState: State(),
+            // Need the fully qualified name here
+            event: APNSLiveActivityNotificationEventStart(
+                attributes: .init(type: "State", state: State())),
+            timestamp: 1_672_680_658)
 
-				let encoder = JSONEncoder()
-				let data = try encoder.encode(notification)
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(notification)
 
-				let expectedJSONString = """
-				{"aps":{"event":"start", "attributes-type": "State", "attributes": {"string":"Test","number":123},"content-state":{"string":"Test","number":123},"timestamp":1672680658}}
-				"""
+        let expectedJSONString = """
+            {"aps":{"event":"start", "attributes-type": "State", "attributes": {"string":"Test","number":123},"content-state":{"string":"Test","number":123},"timestamp":1672680658}}
+            """
 
-				let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
-				let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
-				XCTAssertEqual(jsonObject1, jsonObject2)
-		}
+        let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+        let jsonObject2 =
+            try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!)
+            as! NSDictionary
+        XCTAssertEqual(jsonObject1, jsonObject2)
+    }
 
     func testEncodeEndNoDismiss() throws {
         let notification = APNSLiveActivityNotification(
@@ -72,17 +77,19 @@ final class APNSLiveActivityNotificationTests: XCTestCase {
             appID: "test.app.id",
             contentState: State(),
             event: .end,
-            timestamp: 1672680658)
-        
+            timestamp: 1_672_680_658)
+
         let encoder = JSONEncoder()
         let data = try encoder.encode(notification)
 
         let expectedJSONString = """
-        {"aps":{"event":"end","content-state":{"string":"Test","number":123},"timestamp":1672680658}}
-        """
+            {"aps":{"event":"end","content-state":{"string":"Test","number":123},"timestamp":1672680658}}
+            """
 
         let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
-        let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
+        let jsonObject2 =
+            try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!)
+            as! NSDictionary
         XCTAssertEqual(jsonObject1, jsonObject2)
     }
 
@@ -93,19 +100,21 @@ final class APNSLiveActivityNotificationTests: XCTestCase {
             appID: "test.app.id",
             contentState: State(),
             event: .end,
-            timestamp: 1672680658,
-            dismissalDate: .timeIntervalSince1970InSeconds(1672680800))
-        
+            timestamp: 1_672_680_658,
+            dismissalDate: .timeIntervalSince1970InSeconds(1_672_680_800))
+
         let encoder = JSONEncoder()
         let data = try encoder.encode(notification)
 
         let expectedJSONString = """
-        {"aps":{"event":"end","content-state":{"string":"Test","number":123},"timestamp":1672680658,
-        "dismissal-date":1672680800}}
-        """
+            {"aps":{"event":"end","content-state":{"string":"Test","number":123},"timestamp":1672680658,
+            "dismissal-date":1672680800}}
+            """
 
         let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
-        let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
+        let jsonObject2 =
+            try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!)
+            as! NSDictionary
         XCTAssertEqual(jsonObject1, jsonObject2)
     }
 }


### PR DESCRIPTION
I believe this PR brings things in line with the JSON payload described in [the docs](https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications#Construct-the-payload-that-starts-a-Live-Activity).

This makes the `APNSLiveActivityNotificationEvent` type a bit more clunky to deal with, so I'd love to hear if anyone has any ideas on how to improve that.

I also ran `swift-format --configuration .swift-format` on my changes which seems to have brought in some unrelated format changes. If this is a PR worth pursuing I'm happy to clean those up.

See also https://github.com/swift-server-community/APNSwift/pull/191.