### PR TITLE
Deprecated `.sandbox` in favor of `.development`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ let client = APNSClient(
             keyIdentifier: keyIdentifier,
             teamIdentifier: teamIdentifier
         ),
-        environment: .sandbox
+        environment: .development
     ),
     eventLoopGroupProvider: .createNew,
     responseDecoder: JSONDecoder(),

--- a/Sources/APNS/APNS.docc/APNSwift.md
+++ b/Sources/APNS/APNS.docc/APNSwift.md
@@ -37,7 +37,7 @@ let client = APNSClient(
             keyIdentifier: keyIdentifier,
             teamIdentifier: teamIdentifier
         ),
-        environment: .sandbox
+        environment: .development
     ),
     eventLoopGroupProvider: .createNew,
     responseDecoder: JSONDecoder(),

--- a/Sources/APNSCore/APNSEnvironment.swift
+++ b/Sources/APNSCore/APNSEnvironment.swift
@@ -18,7 +18,11 @@ public struct APNSEnvironment: Sendable {
     public static let production = Self(url: "https://api.push.apple.com", port: 443)
 
     /// The sandbox APNs environment.
-    public static let sandbox = Self(url: "https://api.development.push.apple.com", port: 443)
+    @available(*, deprecated, renamed: "development")
+    public static let sandbox = development
+    
+    /// The development APNs environment.
+    public static let development = Self(url: "https://api.development.push.apple.com", port: 443)
 
     /// Creates an APNs environment with a custom URL.
     ///

--- a/Sources/APNSExample/Program.swift
+++ b/Sources/APNSExample/Program.swift
@@ -37,7 +37,7 @@ struct Main {
                     keyIdentifier: keyIdentifier,
                     teamIdentifier: teamIdentifier
                 ),
-                environment: .sandbox
+                environment: .development
             ),
             eventLoopGroupProvider: .createNew,
             responseDecoder: JSONDecoder(),

--- a/Tests/APNSTests/APNSClientTests.swift
+++ b/Tests/APNSTests/APNSClientTests.swift
@@ -33,7 +33,7 @@ final class APNSClientTests: XCTestCase {
                     keyIdentifier: "MY_KEY_ID",
                     teamIdentifier: "MY_TEAM_ID"
                 ),
-                environment: .sandbox
+                environment: .development
             ),
             eventLoopGroupProvider: .createNew,
             responseDecoder: JSONDecoder(),


### PR DESCRIPTION
Since none of Apple's documentation uses "sandbox" anymore, I deprecated and replaced the `.sandbox` environment with a `.development` one to decrease confusion for newcomers to the library.