### PR TITLE
Fix crash when using AnyEncodable payload for alert and background notifications

### DIFF
--- a/Sources/APNSCore/Alert/APNSAlertNotification.swift
+++ b/Sources/APNSCore/Alert/APNSAlertNotification.swift
@@ -212,11 +212,10 @@ public struct APNSAlertNotification<Payload: Encodable & Sendable>: APNSMessage,
     }
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-
         // First we encode the user payload since this might use the `aps` key
         // and we override it afterward.
         try self.payload.encode(to: encoder)
+        var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.aps, forKey: .aps)
     }
 }

--- a/Sources/APNSCore/Background/APNSBackgroundNotification.swift
+++ b/Sources/APNSCore/Background/APNSBackgroundNotification.swift
@@ -86,11 +86,10 @@ public struct APNSBackgroundNotification<Payload: Encodable & Sendable>: APNSMes
 
     @inlinable
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-
         // First we encode the user payload since this might use the `aps` key
         // and we override it afterward.
         try self.payload.encode(to: encoder)
+        var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.aps, forKey: .aps)
     }
 }


### PR DESCRIPTION
In this update, I've addressed an issue where using [AnyEncodable](https://github.com/Flight-School/AnyCodable/blob/master/Sources/AnyCodable/AnyEncodable.swift) for user-provided notification payloads caused a crash during alert or background notifications. These changes resolve the crash and ensure stable handling of `AnyEncodable` payloads. 