### PR TITLE
Adjust to Swift 6 toolchain compile

### DIFF
--- a/Sources/APNS/APNSClient.swift
+++ b/Sources/APNS/APNSClient.swift
@@ -125,7 +125,7 @@ public final class APNSClient<Decoder: APNSJSONDecoder, Encoder: APNSJSONEncoder
     /// - Parameters:
     ///   - queue: The queue on which the callback is invoked on.
     ///   - callback: The callback that is invoked when everything is shutdown.
-    public func shutdown(queue: DispatchQueue = .global(), callback: @escaping (Error?) -> Void) {
+    public func shutdown(queue: DispatchQueue = .global(), callback: @Sendable @escaping (Error?) -> Void) {
         self.httpClient.shutdown(callback)
     }
 

--- a/Sources/APNS/APNSClient.swift
+++ b/Sources/APNS/APNSClient.swift
@@ -125,7 +125,7 @@ public final class APNSClient<Decoder: APNSJSONDecoder, Encoder: APNSJSONEncoder
     /// - Parameters:
     ///   - queue: The queue on which the callback is invoked on.
     ///   - callback: The callback that is invoked when everything is shutdown.
-    public func shutdown(queue: DispatchQueue = .global(), callback: @Sendable @escaping (Error?) -> Void) {
+    @preconcurrency public func shutdown(queue: DispatchQueue = .global(), callback: @Sendable @escaping (Error?) -> Void) {
         self.httpClient.shutdown(callback)
     }
 

--- a/Sources/APNS/APNSConfiguration.swift
+++ b/Sources/APNS/APNSConfiguration.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import APNSCore
-import Crypto
+@preconcurrency import Crypto
 import NIOSSL
 import NIOTLS
 import AsyncHTTPClient
@@ -22,7 +22,7 @@ import AsyncHTTPClient
 public struct APNSClientConfiguration: Sendable {
     /// The authentication method used by the ``APNSClient``.
     public struct AuthenticationMethod: Sendable {
-        internal enum Method {
+        internal enum Method : Sendable{
             case jwt(privateKey: P256.Signing.PrivateKey, teamIdentifier: String, keyIdentifier: String)
             case tls(privateKey: NIOSSLPrivateKeySource, certificateChain: [NIOSSLCertificateSource])
         }

--- a/Sources/APNSCore/APNSError.swift
+++ b/Sources/APNSCore/APNSError.swift
@@ -21,8 +21,8 @@ public struct APNSError: Error {
     /// The error reason returned by APNs.
     ///
     /// For more information please look here: [Reference]( https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns)
-    public struct ErrorReason: Hashable {
-        public enum Reason: RawRepresentable, Hashable {
+    public struct ErrorReason: Hashable, Sendable {
+        public enum Reason: RawRepresentable, Hashable, Sendable {
             public typealias RawValue = String
 
             case badCollapseIdentifier

--- a/Sources/APNSCore/Base64.swift
+++ b/Sources/APNSCore/Base64.swift
@@ -89,7 +89,7 @@ internal enum Base64 {}
 
 extension Base64 {
     @usableFromInline
-    internal struct EncodingOptions: OptionSet {
+    internal struct EncodingOptions: OptionSet, Sendable {
         @usableFromInline
         internal let rawValue: UInt
 
@@ -557,7 +557,7 @@ extension Base64 {
 
 extension Base64 {
     @usableFromInline
-    internal struct DecodingOptions: OptionSet {
+    internal struct DecodingOptions: OptionSet, Sendable {
         @usableFromInline
         internal let rawValue: UInt
 

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityDismissalDate.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityDismissalDate.swift
@@ -14,7 +14,7 @@
 
 import struct Foundation.Date
 
-public struct APNSLiveActivityDismissalDate: Hashable {
+public struct APNSLiveActivityDismissalDate: Hashable, Sendable {
     /// The date at which the live activity will be dismissed
     /// This value is a UNIX epoch expressed in seconds (UTC)
     @usableFromInline

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
@@ -17,7 +17,7 @@ import struct Foundation.UUID
 /// A live activity notification.
 ///
 /// It is **important** that you do not encode anything with the key `aps`.
-public struct APNSLiveActivityNotification<ContentState: Encodable>: APNSMessage {
+public struct APNSLiveActivityNotification<ContentState: Encodable & Sendable>: APNSMessage {
     enum CodingKeys: CodingKey {
         case aps
     }

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable>: Encodable {
+struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable & Sendable>: Encodable {
     enum CodingKeys: String, CodingKey {
         case timestamp = "timestamp"
         case event = "event"

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct APNSLiveActivityNotificationEvent: Hashable {
+public struct APNSLiveActivityNotificationEvent: Hashable, Sendable {
     /// The underlying raw value that is send to APNs.
     @usableFromInline
     internal let rawValue: String

--- a/Sources/APNSCore/LiveActivity/APNSStartLiveActivityNotification.swift
+++ b/Sources/APNSCore/LiveActivity/APNSStartLiveActivityNotification.swift
@@ -17,7 +17,7 @@ import struct Foundation.UUID
 /// A notification that starts a live activity
 ///
 /// It is **important** that you do not encode anything with the key `aps`.
-public struct APNSStartLiveActivityNotification<Attributes: Encodable, ContentState: Encodable>:
+public struct APNSStartLiveActivityNotification<Attributes: Encodable & Sendable, ContentState: Encodable & Sendable>:
     APNSMessage
 {
     enum CodingKeys: CodingKey {

--- a/Sources/APNSCore/LiveActivity/APNSStartLiveActivityNotificationAPSStorage.swift
+++ b/Sources/APNSCore/LiveActivity/APNSStartLiveActivityNotificationAPSStorage.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-struct APNSStartLiveActivityNotificationAPSStorage<Attributes: Encodable, ContentState: Encodable>:
-    Encodable
+struct APNSStartLiveActivityNotificationAPSStorage<Attributes: Encodable & Sendable, ContentState: Encodable & Sendable>:
+    Encodable & Sendable
 {
     enum CodingKeys: String, CodingKey {
         case timestamp = "timestamp"

--- a/Sources/APNSURLSession/APNSURLSessionClientConfiguration.swift
+++ b/Sources/APNSURLSession/APNSURLSessionClientConfiguration.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import APNSCore
-import Crypto
+@preconcurrency import Crypto
 
 /// The configuration of an ``APNSURLSessionClient``.
 public struct APNSURLSessionClientConfiguration {


### PR DESCRIPTION
use the build command provided by Swift Package Index below to verify this package can be migrated to Swift 6 gracefully

```bash
env DEVELOPER_DIR=/Applications/Xcode-16.0.0-Beta.3.app xcrun swift build --arch arm64 -Xswiftc -strict-concurrency=complete
```

Reference this WWDC24 video to make change: https://developer.apple.com/wwdc24/10169

and the Guide to Migrate to Swift 6 on Swift Package Index: https://swiftpackageindex.com/ready-for-swift-6

If this PR is merged, after triggering the Swift Package Index build workflow, you can see the main branch be Safe from data race logo on the homepage of this package as below:

![image](https://github.com/user-attachments/assets/79a370c4-a07a-40ce-b377-63d64eccc6c1)

