### PR TITLE
Privatize APNSPushType

### DIFF
--- a/Sources/APNS/APNSClient.swift
+++ b/Sources/APNS/APNSClient.swift
@@ -145,7 +145,7 @@ extension APNSClient {
         var headers = self.defaultRequestHeaders
 
         // Push type
-        headers.add(name: "apns-push-type", value: request.pushType.configuration.rawValue)
+        headers.add(name: "apns-push-type", value: request.pushType.description)
 
         // APNS ID
         if let apnsID = request.apnsID {

--- a/Sources/APNSCore/APNSPushType.swift
+++ b/Sources/APNSCore/APNSPushType.swift
@@ -13,8 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 /// A struct which represents the different supported APNs push types.
-public struct APNSPushType: Hashable, Sendable {
-    public enum Configuration: String, Hashable, Sendable {
+public struct APNSPushType: Hashable, Sendable, CustomStringConvertible {
+    
+    internal enum Configuration: String, Hashable, Sendable {
         case alert
         case background
         case location
@@ -24,9 +25,13 @@ public struct APNSPushType: Hashable, Sendable {
         case mdm
         case liveactivity
     }
+    
+    public var description: String {
+        configuration.rawValue
+    }
 
     /// The underlying raw value that is send to APNs.
-    public var configuration: Configuration
+    internal var configuration: Configuration
 
     /// Use the alert push type for notifications that trigger a user interaction—for example, an alert, badge, or sound.
     ///


### PR DESCRIPTION
This puts the `APNSPushType` back behind a private enum so that it won't be a breaking change when new ones are added.