### PR TITLE
Fix `.spi.yml`

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -3,3 +3,4 @@ builder:
   configs:
     - documentation_targets: [APNS]
       scheme: APNS
+      swift_version: 6.0


### PR DESCRIPTION
The SPI hasn't switched the default documentation Swift version to 6.0 yet so we need to specify that manually to actually get the docs to build (right now they're stuck on the old broken version).