### PR TITLE
add live activity start event

### DIFF
--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationEvent.swift
@@ -17,6 +17,9 @@ public struct APNSLiveActivityNotificationEvent: Hashable, Sendable {
     @usableFromInline
     internal let rawValue: String
 
+    /// Specifies that live activity should be started
+    public static let start = Self(rawValue: "start")
+    
     /// Specifies that live activity should be updated
     public static let update = Self(rawValue: "update")
 


### PR DESCRIPTION
Hi,
thank you for this awesome project! 🙏

I've added the `start` event for [live activities](https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications#Construct-the-payload-that-starts-a-Live-Activity).