### PR TITLE
Mark APNSResponse and APNSErrorResponse as Sendable

### DIFF
--- a/Sources/APNSCore/APNSErrorResponse.swift
+++ b/Sources/APNSCore/APNSErrorResponse.swift
@@ -15,7 +15,7 @@
 /// A struct for the error response of APNs.
 ///
 /// This is just used to decode the JSON and should not be exposed.
-public struct APNSErrorResponse: Codable {
+public struct APNSErrorResponse: Codable, Sendable {
     /// The error code indicating the reason for the failure.
     public var reason: String
 

--- a/Sources/APNSCore/APNSResponse.swift
+++ b/Sources/APNSCore/APNSResponse.swift
@@ -15,7 +15,7 @@
 import struct Foundation.UUID
 
 /// The response of a successful APNs request.
-public struct APNSResponse: Hashable {
+public struct APNSResponse: Hashable, Sendable {
     /// The same value as the `apnsID` send in the request.
     ///
     /// Use this value to identify the notification. If you don’t specify an `apnsID` in your request,

--- a/Tests/APNSTests/APNSClientTests.swift
+++ b/Tests/APNSTests/APNSClientTests.swift
@@ -50,3 +50,18 @@ final class APNSClientTests: XCTestCase {
     -----END PRIVATE KEY-----
     """
 }
+
+// This doesn't perform any runtime tests, it just ensures the call to sendAlertNotification
+// compiles when called within an actor's isolation context.
+actor TestActor {
+    func sendAlert(client: APNSClient<JSONDecoder, JSONEncoder>) async throws {
+        let notification = APNSAlertNotification(
+            alert: .init(title: .raw("title")),
+            expiration: .immediately,
+            priority: .immediately,
+            topic: "",
+            payload: ""
+        )
+        try await client.sendAlertNotification(notification, deviceToken: "")
+    }
+}


### PR DESCRIPTION
This ensures you can send notifications within an actor isolated context.

Fixes #217