### PR TITLE
Add optional alert to live activity

### DIFF
--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
@@ -100,6 +100,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Sendable>: 
     ///   - apnsID: A canonical UUID that identifies the notification.
     ///   - contentState: Updated content-state of live activity
     ///   - event: event type e.g. update
+    ///   - alert: Optional alert content for the notification.
     ///   - timestamp: Timestamp when sending notification
     ///   - dismissalDate: Timestamp when to dismiss live notification when sent with `end`, if in the past
     ///    dismiss immediately
@@ -109,6 +110,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Sendable>: 
         appID: String,
         contentState: ContentState,
         event: APNSLiveActivityNotificationEvent,
+        alert: APNSAlertNotificationContent? = nil,
         timestamp: Int,
         dismissalDate: APNSLiveActivityDismissalDate = .none,
         apnsID: UUID? = nil
@@ -119,6 +121,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Sendable>: 
             topic: appID + ".push-type.liveactivity",
             contentState: contentState,
             event: event,
+            alert: alert,
             timestamp: timestamp,
             dismissalDate: dismissalDate
         )
@@ -136,6 +139,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Sendable>: 
     ///   - apnsID: A canonical UUID that identifies the notification.
     ///   - contentState: Updated content-state of live activity
     ///   - event: event type e.g. update
+    ///   - alert: Optional alert content for the notification.
     ///   - timestamp: Timestamp when sending notification
     ///   - dismissalDate: Timestamp when to dismiss live notification when sent with `end`, if in the past
     ///    dismiss immediately
@@ -146,6 +150,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Sendable>: 
         apnsID: UUID? = nil,
         contentState: ContentState,
         event: APNSLiveActivityNotificationEvent,
+        alert: APNSAlertNotificationContent? = nil,
         timestamp: Int,
         dismissalDate: APNSLiveActivityDismissalDate = .none
     ) {
@@ -153,7 +158,8 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Sendable>: 
             timestamp: timestamp,
             event: event.rawValue,
             contentState: contentState,
-            dismissalDate: dismissalDate.dismissal
+            dismissalDate: dismissalDate.dismissal,
+            alert: alert
         )
         self.apnsID = apnsID
         self.expiration = expiration

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
@@ -18,22 +18,26 @@ struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable & Sendable
         case event = "event"
         case contentState = "content-state"
         case dismissalDate = "dismissal-date"
+        case alert = "alert"
     }
 
     var timestamp: Int
     var event: String
     var contentState: ContentState
     var dismissalDate: Int?
+    var alert: APNSAlertNotificationContent?
 
     init(
         timestamp: Int,
         event: String,
         contentState: ContentState,
-        dismissalDate: Int?
+        dismissalDate: Int?,
+        alert: APNSAlertNotificationContent? = nil
     ) {
         self.timestamp = timestamp
         self.contentState = contentState
         self.dismissalDate = dismissalDate
         self.event = event
+        self.alert = alert
     }
 }

--- a/Tests/APNSTests/LiveActivity/APNSLiveActivityNotificationTests.swift
+++ b/Tests/APNSTests/LiveActivity/APNSLiveActivityNotificationTests.swift
@@ -49,6 +49,31 @@ final class APNSLiveActivityNotificationTests: XCTestCase {
         XCTAssertEqual(jsonObject1, jsonObject2)
     }
 
+    func testEncodeUpdateAlert() throws {
+        let notification = APNSLiveActivityNotification(
+            expiration: .immediately,
+            priority: .immediately,
+            appID: "test.app.id",
+            contentState: State(),
+            event: .update,
+            alert: .init(title: .raw("Hi"), body: .raw("Hello")),
+            timestamp: 1_672_680_658
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(notification)
+
+        let expectedJSONString = """
+            {"aps":{"event":"update", "alert": { "title": "Hi", "body": "Hello" },"content-state":{"string":"Test","number":123},"timestamp":1672680658}}
+            """
+
+        let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+        let jsonObject2 =
+            try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!)
+            as! NSDictionary
+        XCTAssertEqual(jsonObject1, jsonObject2)
+    }
+
     func testEncodeStart() throws {
         let notification = APNSStartLiveActivityNotification(
             expiration: .immediately,


### PR DESCRIPTION
This allows you to send alerts along with a live activity update