### PR TITLE
Remove expiration and priority from widgets

### DIFF
--- a/Sources/APNSCore/Widgets/APNSClient+Widgets.swift
+++ b/Sources/APNSCore/Widgets/APNSClient+Widgets.swift
@@ -32,8 +32,8 @@ extension APNSClientProtocol {
             message: notification,
             deviceToken: deviceToken,
             pushType: .widgets,
-            expiration: notification.expiration,
-            priority: notification.priority,
+            expiration: nil,
+            priority: nil,
             apnsID: notification.apnsID,
             topic: notification.topic,
             collapseID: nil

--- a/Sources/APNSCore/Widgets/APNSWidgetsNotification.swift
+++ b/Sources/APNSCore/Widgets/APNSWidgetsNotification.swift
@@ -45,33 +45,17 @@ public struct APNSWidgetsNotification: APNSMessage {
     /// The topic for the notification. In general, the topic is your app’s bundle ID/app ID suffixed with `.push-type.widgets`.
     public var topic: String
 
-    /// The date when the notification is no longer valid and can be discarded. If this value is not `none`,
-    /// APNs stores the notification and tries to deliver it at least once,
-    /// repeating the attempt as needed if it is unable to deliver the notification the first time.
-    /// If the value is `immediately`, APNs treats the notification as if it expires immediately
-    /// and does not store the notification or attempt to redeliver it.
-    public var expiration: APNSNotificationExpiration
-
-    /// The priority of the notification.
-    public var priority: APNSPriority
-
     /// Initializes a new ``APNSWidgetsNotification``.
     ///
     /// - Parameters:
-    ///   - expiration: The date when the notification is no longer valid and can be discarded.
-    ///   - priority: The priority of the notification.
     ///   - appID: Your app’s bundle ID/app ID. This will be suffixed with `.push-type.widgets`.
     ///   - apnsID: A canonical UUID that identifies the notification.
     @inlinable
     public init(
-        expiration: APNSNotificationExpiration,
-        priority: APNSPriority,
         appID: String,
         apnsID: UUID? = nil
     ) {
         self.init(
-            expiration: expiration,
-            priority: priority,
             topic: appID + ".push-type.widgets",
             apnsID: apnsID
         )
@@ -80,19 +64,13 @@ public struct APNSWidgetsNotification: APNSMessage {
     /// Initializes a new ``APNSWidgetsNotification``.
     ///
     /// - Parameters:
-    ///   - expiration: The date when the notification is no longer valid and can be discarded.
-    ///   - priority: The priority of the notification.
     ///   - topic: The topic for the notification. In general, the topic is your app’s bundle ID/app ID suffixed with `.push-type.widgets`.
     ///   - apnsID: A canonical UUID that identifies the notification.
     @inlinable
     public init(
-        expiration: APNSNotificationExpiration,
-        priority: APNSPriority,
         topic: String,
         apnsID: UUID? = nil
     ) {
-        self.expiration = expiration
-        self.priority = priority
         self.topic = topic
         self.apnsID = apnsID
     }

--- a/Tests/APNSTests/Widgets/APNSWidgetsNotificationTests.swift
+++ b/Tests/APNSTests/Widgets/APNSWidgetsNotificationTests.swift
@@ -17,21 +17,12 @@ import XCTest
 
 final class APNSWidgetsNotificationTests: XCTestCase {
     func testAppID() {
-        let widgetsNotification = APNSWidgetsNotification(
-            expiration: .none,
-            priority: .immediately,
-            appID: "com.example.app"
-        )
-
+        let widgetsNotification = APNSWidgetsNotification(appID: "com.example.app")
         XCTAssertEqual(widgetsNotification.topic, "com.example.app.push-type.widgets")
     }
 
     func testEncode() throws {
-        let widgetsNotification = APNSWidgetsNotification(
-            expiration: .none,
-            priority: .immediately,
-            appID: "com.example.app"
-        )
+        let widgetsNotification = APNSWidgetsNotification(appID: "com.example.app")
 
         let encoder = JSONEncoder()
         let data = try encoder.encode(widgetsNotification)


### PR DESCRIPTION
It seems that at least setting an expiration can prevent them from working as expected ([discussion](https://mastodon.social/@simonbs/114765381174946107)). Since the example in the docs set neither an expiration nor a priority, removing both from the API.