### PR TITLE
Making APNSClient's Sendable conformance public

### DIFF
--- a/Sources/APNS/APNSClient.swift
+++ b/Sources/APNS/APNSClient.swift
@@ -119,7 +119,7 @@ public final class APNSClient<Decoder: APNSJSONDecoder, Encoder: APNSJSONEncoder
     }
 }
 
-extension APNSClient: Sendable where Decoder: Sendable, Encoder: Sendable {}
+public extension APNSClient: Sendable where Decoder: Sendable, Encoder: Sendable {}
 
 // MARK: - Raw sending
 


### PR DESCRIPTION
Just a one-liner, but this was useful for me to inject APNSClient into Vapor's StorageKey as described in #222.