### PR TITLE
Add stale-date parameter to LiveActivity payloads

### DIFF
--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
@@ -104,6 +104,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Sendable>: 
     ///   - timestamp: Timestamp when sending notification
     ///   - dismissalDate: Timestamp when to dismiss live notification when sent with `end`, if in the past
     ///    dismiss immediately
+    ///   - staleDate: Timestamp when the notification is marked as stale
     public init(
         expiration: APNSNotificationExpiration,
         priority: APNSPriority,
@@ -113,17 +114,20 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Sendable>: 
         alert: APNSAlertNotificationContent? = nil,
         timestamp: Int,
         dismissalDate: APNSLiveActivityDismissalDate = .none,
+        staleDate: Int? = nil,
         apnsID: UUID? = nil
     ) {
         self.init(
             expiration: expiration,
             priority: priority,
             topic: appID + ".push-type.liveactivity",
+            apnsID: apnsID,
             contentState: contentState,
             event: event,
             alert: alert,
             timestamp: timestamp,
-            dismissalDate: dismissalDate
+            dismissalDate: dismissalDate,
+            staleDate: staleDate,
         )
     }
 
@@ -143,6 +147,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Sendable>: 
     ///   - timestamp: Timestamp when sending notification
     ///   - dismissalDate: Timestamp when to dismiss live notification when sent with `end`, if in the past
     ///    dismiss immediately
+    ///   - staleDate: Timestamp when the notification is marked as stale
     public init(
         expiration: APNSNotificationExpiration,
         priority: APNSPriority,
@@ -152,13 +157,15 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Sendable>: 
         event: APNSLiveActivityNotificationEvent,
         alert: APNSAlertNotificationContent? = nil,
         timestamp: Int,
-        dismissalDate: APNSLiveActivityDismissalDate = .none
+        dismissalDate: APNSLiveActivityDismissalDate = .none,
+        staleDate: Int? = nil
     ) {
         self.aps = APNSLiveActivityNotificationAPSStorage(
             timestamp: timestamp,
             event: event.rawValue,
             contentState: contentState,
             dismissalDate: dismissalDate.dismissal,
+            staleDate: staleDate,
             alert: alert
         )
         self.apnsID = apnsID

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
@@ -100,6 +100,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Sendable>: 
     ///   - apnsID: A canonical UUID that identifies the notification.
     ///   - contentState: Updated content-state of live activity
     ///   - event: event type e.g. update
+    ///   - alert: Optional alert content for the notification.
     ///   - timestamp: Timestamp when sending notification
     ///   - dismissalDate: Timestamp when to dismiss live notification when sent with `end`, if in the past
     ///    dismiss immediately
@@ -109,6 +110,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Sendable>: 
         appID: String,
         contentState: ContentState,
         event: APNSLiveActivityNotificationEvent,
+        alert: APNSAlertNotificationContent? = nil,
         timestamp: Int,
         dismissalDate: APNSLiveActivityDismissalDate = .none,
         apnsID: UUID? = nil
@@ -119,6 +121,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Sendable>: 
             topic: appID + ".push-type.liveactivity",
             contentState: contentState,
             event: event,
+            alert: alert,
             timestamp: timestamp,
             dismissalDate: dismissalDate
         )
@@ -136,6 +139,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Sendable>: 
     ///   - apnsID: A canonical UUID that identifies the notification.
     ///   - contentState: Updated content-state of live activity
     ///   - event: event type e.g. update
+    ///   - alert: Optional alert content for the notification.
     ///   - timestamp: Timestamp when sending notification
     ///   - dismissalDate: Timestamp when to dismiss live notification when sent with `end`, if in the past
     ///    dismiss immediately
@@ -146,6 +150,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Sendable>: 
         apnsID: UUID? = nil,
         contentState: ContentState,
         event: APNSLiveActivityNotificationEvent,
+        alert: APNSAlertNotificationContent? = nil,
         timestamp: Int,
         dismissalDate: APNSLiveActivityDismissalDate = .none
     ) {
@@ -153,7 +158,8 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Sendable>: 
             timestamp: timestamp,
             event: event.rawValue,
             contentState: contentState,
-            dismissalDate: dismissalDate.dismissal
+            dismissalDate: dismissalDate.dismissal,
+            alert: alert
         )
         self.apnsID = apnsID
         self.expiration = expiration

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotification.swift
@@ -127,7 +127,7 @@ public struct APNSLiveActivityNotification<ContentState: Encodable & Sendable>: 
             alert: alert,
             timestamp: timestamp,
             dismissalDate: dismissalDate,
-            staleDate: staleDate,
+            staleDate: staleDate
         )
     }
 

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
@@ -18,22 +18,26 @@ struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable & Sendable
         case event = "event"
         case contentState = "content-state"
         case dismissalDate = "dismissal-date"
+        case alert = "alert"
     }
 
     var timestamp: Int
     var event: String
     var contentState: ContentState
     var dismissalDate: Int?
+    var alert: APNSAlertNotificationContent?
 
     init(
         timestamp: Int,
         event: String,
         contentState: ContentState,
-        dismissalDate: Int?
+        dismissalDate: Int?,
+        alert: APNSAlertNotificationContent? = nil
     ) {
         self.timestamp = timestamp
         self.contentState = contentState
         self.dismissalDate = dismissalDate
         self.event = event
+        self.alert = alert
     }
 }

--- a/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
+++ b/Sources/APNSCore/LiveActivity/APNSLiveActivityNotificationAPSStorage.swift
@@ -18,6 +18,7 @@ struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable & Sendable
         case event = "event"
         case contentState = "content-state"
         case dismissalDate = "dismissal-date"
+        case staleDate = "stale-date"
         case alert = "alert"
     }
 
@@ -25,6 +26,7 @@ struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable & Sendable
     var event: String
     var contentState: ContentState
     var dismissalDate: Int?
+    var staleDate: Int?
     var alert: APNSAlertNotificationContent?
 
     init(
@@ -32,11 +34,13 @@ struct APNSLiveActivityNotificationAPSStorage<ContentState: Encodable & Sendable
         event: String,
         contentState: ContentState,
         dismissalDate: Int?,
+        staleDate: Int?,
         alert: APNSAlertNotificationContent? = nil
     ) {
         self.timestamp = timestamp
         self.contentState = contentState
         self.dismissalDate = dismissalDate
+        self.staleDate = staleDate
         self.event = event
         self.alert = alert
     }

--- a/Tests/APNSTests/LiveActivity/APNSLiveActivityNotificationTests.swift
+++ b/Tests/APNSTests/LiveActivity/APNSLiveActivityNotificationTests.swift
@@ -49,6 +49,31 @@ final class APNSLiveActivityNotificationTests: XCTestCase {
         XCTAssertEqual(jsonObject1, jsonObject2)
     }
 
+    func testEncodeUpdateStale() throws {
+        let notification = APNSLiveActivityNotification(
+            expiration: .immediately,
+            priority: .immediately,
+            appID: "test.app.id",
+            contentState: State(),
+            event: .update,
+            timestamp: 1_672_680_658,
+            staleDate: 1_672_680_800)
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(notification)
+
+        let expectedJSONString = """
+            {"aps":{"event":"update","content-state":{"string":"Test","number":123},"timestamp":1672680658,
+            "stale-date":1672680800}}
+            """
+
+        let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+        let jsonObject2 =
+            try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!)
+            as! NSDictionary
+        XCTAssertEqual(jsonObject1, jsonObject2)
+    }
+
     func testEncodeUpdateAlert() throws {
         let notification = APNSLiveActivityNotification(
             expiration: .immediately,

--- a/Tests/APNSTests/LiveActivity/APNSLiveActivityNotificationTests.swift
+++ b/Tests/APNSTests/LiveActivity/APNSLiveActivityNotificationTests.swift
@@ -49,6 +49,31 @@ final class APNSLiveActivityNotificationTests: XCTestCase {
         XCTAssertEqual(jsonObject1, jsonObject2)
     }
 
+    func testEncodeUpdateAlert() throws {
+        let notification = APNSLiveActivityNotification(
+            expiration: .immediately,
+            priority: .immediately,
+            appID: "test.app.id",
+            contentState: State(),
+            event: .update,
+            alert: .init(title: .raw("Hi"), body: .raw("Hello")),
+            timestamp: 1_672_680_658
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(notification)
+
+        let expectedJSONString = """
+            {"aps":{"event":"update", "alert": { "title": "Hi", "body": "Hello" },"content-state":{"string":"Test","number":123},"timestamp":1672680658}}
+            """
+
+        let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+        let jsonObject2 =
+            try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!)
+            as! NSDictionary
+        XCTAssertEqual(jsonObject1, jsonObject2)
+    }
+
     func testEncodeStart() throws {
         let notification = APNSStartLiveActivityNotification(
             expiration: .immediately,


### PR DESCRIPTION
Adds stale-date parameter to LiveActivity payloads as described here: https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications