### PR TITLE
Adding Package.swift for Swift 5 versions

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -23,3 +23,24 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - run: ASAN_OPTIONS=detect_leaks=0 swift test --sanitize=address
+  focal-5-10:
+    container:
+      image: swift:5.10-focal
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: swift test
+  thread-5-10:
+    container:
+      image: swift:5.10-focal
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: swift test --sanitize=thread
+  address-5-10:
+    container:
+      image: swift:5.10-focal
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: ASAN_OPTIONS=detect_leaks=0 swift test --sanitize=address

--- a/Package@swift-5.10.swift
+++ b/Package@swift-5.10.swift
@@ -1,0 +1,77 @@
+// swift-tools-version:5.10
+import PackageDescription
+
+let package = Package(
+    name: "apnswift",
+    platforms: [
+        .macOS(.v13),
+        .iOS(.v16),
+        .watchOS(.v9),
+        .tvOS(.v16),
+    ],
+    products: [
+        .executable(name: "APNSExample", targets: ["APNSExample"]),
+        .library(name: "APNS", targets: ["APNS"]),
+        .library(name: "APNSCore", targets: ["APNSCore"]),
+        .library(name: "APNSURLSession", targets: ["APNSURLSession"]),
+        .library(name: "APNSTestServer", targets: ["APNSTestServer"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "3.0.0"..<"5.0.0"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.6.0"),
+        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.9.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "APNSExample",
+            dependencies: [
+                .target(name: "APNSCore"),
+                .target(name: "APNS"),
+                .product(name: "Logging", package: "swift-log"),
+            ]
+        ),
+        .testTarget(
+            name: "APNSTests",
+            dependencies: [
+                .target(name: "APNSCore"),
+                .target(name: "APNS"),
+            ]
+        ),
+        .target(
+            name: "APNSCore",
+            dependencies: [
+                .product(name: "Crypto", package: "swift-crypto")
+            ]
+        ),
+        .target(
+            name: "APNS",
+            dependencies: [
+                .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "AsyncHTTPClient", package: "async-http-client"),
+                .target(name: "APNSCore"),
+            ]
+        ),
+        .target(
+            name: "APNSTestServer",
+            dependencies: [
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
+                .product(name: "NIOSSL", package: "swift-nio-ssl"),
+                .product(name: "NIOHTTP1", package: "swift-nio"),
+                .product(name: "NIOHTTP2", package: "swift-nio-http2"),
+            ]
+        ),
+        .target(
+            name: "APNSURLSession",
+            dependencies: [
+                .target(name: "APNSCore")
+            ]
+        ),
+    ]
+)


### PR DESCRIPTION
I needed to deploy this library to my Swift 5 server, so I had to make a new Package.swift that wasn't tied to Swift 6 to make it work.

The two changes are:
- `// swift-tools-version:6.0` -> `// swift-tools-version:5.10`
- Removed `swiftLanguageModes: [.v6]`

Let me know if any changes are needed, happy to accept all feedback if you have another preferred way of doing this.