### PR TITLE
Add staleDate to APNSStartLiveActivityNotification

### DIFF
--- a/Sources/APNSCore/LiveActivity/APNSStartLiveActivityNotification.swift
+++ b/Sources/APNSCore/LiveActivity/APNSStartLiveActivityNotification.swift
@@ -102,6 +102,7 @@ public struct APNSStartLiveActivityNotification<Attributes: Encodable & Sendable
     ///   - timestamp: Timestamp when sending notification
     ///   - dismissalDate: Timestamp when to dismiss live notification when sent with `end`, if in the past
     ///    dismiss immediately
+    ///   - staleDate: Timestamp when the notification is marked as stale
     ///   - apnsID: A canonical UUID that identifies the notification.
     ///   - attributes: The ActivityAttributes of the live activity to start
     ///   - attributesType: The type name of the ActivityAttributes you want to send
@@ -113,6 +114,7 @@ public struct APNSStartLiveActivityNotification<Attributes: Encodable & Sendable
         contentState: ContentState,
         timestamp: Int,
         dismissalDate: APNSLiveActivityDismissalDate = .none,
+        staleDate: Int? = nil,
         apnsID: UUID? = nil,
         attributes: Attributes,
         attributesType: String,
@@ -122,6 +124,7 @@ public struct APNSStartLiveActivityNotification<Attributes: Encodable & Sendable
           timestamp: timestamp,
           contentState: contentState,
           dismissalDate: dismissalDate.dismissal,
+          staleDate: staleDate,
           alert: alert,
           attributes: attributes,
           attributesType: attributesType

--- a/Sources/APNSCore/LiveActivity/APNSStartLiveActivityNotificationAPSStorage.swift
+++ b/Sources/APNSCore/LiveActivity/APNSStartLiveActivityNotificationAPSStorage.swift
@@ -20,6 +20,7 @@ struct APNSStartLiveActivityNotificationAPSStorage<Attributes: Encodable & Senda
         case event = "event"
         case contentState = "content-state"
         case dismissalDate = "dismissal-date"
+        case staleDate = "stale-date"
         case alert = "alert"
         case attributes = "attributes"
         case attributesType = "attributes-type"
@@ -29,6 +30,7 @@ struct APNSStartLiveActivityNotificationAPSStorage<Attributes: Encodable & Senda
     var event: String = "start"
     var contentState: ContentState
     var dismissalDate: Int?
+    var staleDate: Int?
     var alert: APNSAlertNotificationContent
     var attributes: Attributes
     var attributesType: String
@@ -37,6 +39,7 @@ struct APNSStartLiveActivityNotificationAPSStorage<Attributes: Encodable & Senda
         timestamp: Int,
         contentState: ContentState,
         dismissalDate: Int?,
+        staleDate: Int?,
         alert: APNSAlertNotificationContent,
         attributes: Attributes,
         attributesType: String
@@ -44,6 +47,7 @@ struct APNSStartLiveActivityNotificationAPSStorage<Attributes: Encodable & Senda
         self.timestamp = timestamp
         self.contentState = contentState
         self.dismissalDate = dismissalDate
+        self.staleDate = staleDate
         self.alert = alert
         self.attributes = attributes
         self.attributesType = attributesType

--- a/Tests/APNSTests/LiveActivity/APNSLiveActivityNotificationTests.swift
+++ b/Tests/APNSTests/LiveActivity/APNSLiveActivityNotificationTests.swift
@@ -106,6 +106,7 @@ final class APNSLiveActivityNotificationTests: XCTestCase {
             appID: "test.app.id",
             contentState: State(),
             timestamp: 1_672_680_658,
+            staleDate: 1_672_680_800,
             attributes: Attributes(),
             attributesType: "Attributes",
             alert: .init(title: .raw("Hi"), body: .raw("Hello"))
@@ -115,7 +116,8 @@ final class APNSLiveActivityNotificationTests: XCTestCase {
         let data = try encoder.encode(notification)
 
         let expectedJSONString = """
-            {"aps":{"event":"start", "alert": { "title": "Hi", "body": "Hello" }, "attributes-type": "Attributes", "attributes": {"name":"Test Attribute"},"content-state":{"string":"Test","number":123},"timestamp":1672680658}}
+            {"aps":{"event":"start", "alert": { "title": "Hi", "body": "Hello" }, "attributes-type": "Attributes", "attributes": {"name":"Test Attribute"},"content-state":{"string":"Test","number":123},"timestamp":1672680658,
+            "stale-date":1672680800}}
             """
 
         let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary


### PR DESCRIPTION
This adds support for `staleState` in `APNSStartLiveActivityNotification`.

https://github.com/swift-server-community/APNSwift/pull/224 added this to `APNSLiveActivityNotification` but a stale date can also be set when starting a Live Activity.