### PR TITLE
Remove dismissalDate from APNSStartLiveActivityNotification

### DIFF
--- a/Sources/APNSCore/LiveActivity/APNSStartLiveActivityNotification.swift
+++ b/Sources/APNSCore/LiveActivity/APNSStartLiveActivityNotification.swift
@@ -59,15 +59,6 @@ public struct APNSStartLiveActivityNotification<Attributes: Encodable & Sendable
         }
     }
 
-    public var dismissalDate: APNSLiveActivityDismissalDate? {
-        get {
-            return .init(dismissal: self.aps.dismissalDate)
-        }
-        set {
-            self.aps.dismissalDate = newValue?.dismissal
-        }
-    }
-
     /// A canonical UUID that identifies the notification. If there is an error sending the notification,
     /// APNs uses this value to identify the notification to your server. The canonical form is 32 lowercase hexadecimal digits,
     /// displayed in five groups separated by hyphens in the form 8-4-4-4-12. An example UUID is as follows:
@@ -100,8 +91,6 @@ public struct APNSStartLiveActivityNotification<Attributes: Encodable & Sendable
     ///   - appID: Your app’s bundle ID/app ID. This will be suffixed with `.push-type.liveactivity`.
     ///   - contentState: Updated content-state of live activity
     ///   - timestamp: Timestamp when sending notification
-    ///   - dismissalDate: Timestamp when to dismiss live notification when sent with `end`, if in the past
-    ///    dismiss immediately
     ///   - apnsID: A canonical UUID that identifies the notification.
     ///   - attributes: The ActivityAttributes of the live activity to start
     ///   - attributesType: The type name of the ActivityAttributes you want to send
@@ -112,7 +101,6 @@ public struct APNSStartLiveActivityNotification<Attributes: Encodable & Sendable
         appID: String,
         contentState: ContentState,
         timestamp: Int,
-        dismissalDate: APNSLiveActivityDismissalDate = .none,
         apnsID: UUID? = nil,
         attributes: Attributes,
         attributesType: String,
@@ -121,7 +109,6 @@ public struct APNSStartLiveActivityNotification<Attributes: Encodable & Sendable
       self.aps = APNSStartLiveActivityNotificationAPSStorage(
           timestamp: timestamp,
           contentState: contentState,
-          dismissalDate: dismissalDate.dismissal,
           alert: alert,
           attributes: attributes,
           attributesType: attributesType

--- a/Sources/APNSCore/LiveActivity/APNSStartLiveActivityNotificationAPSStorage.swift
+++ b/Sources/APNSCore/LiveActivity/APNSStartLiveActivityNotificationAPSStorage.swift
@@ -19,7 +19,6 @@ struct APNSStartLiveActivityNotificationAPSStorage<Attributes: Encodable & Senda
         case timestamp = "timestamp"
         case event = "event"
         case contentState = "content-state"
-        case dismissalDate = "dismissal-date"
         case alert = "alert"
         case attributes = "attributes"
         case attributesType = "attributes-type"
@@ -28,7 +27,6 @@ struct APNSStartLiveActivityNotificationAPSStorage<Attributes: Encodable & Senda
     var timestamp: Int
     var event: String = "start"
     var contentState: ContentState
-    var dismissalDate: Int?
     var alert: APNSAlertNotificationContent
     var attributes: Attributes
     var attributesType: String
@@ -36,14 +34,12 @@ struct APNSStartLiveActivityNotificationAPSStorage<Attributes: Encodable & Senda
     init(
         timestamp: Int,
         contentState: ContentState,
-        dismissalDate: Int?,
         alert: APNSAlertNotificationContent,
         attributes: Attributes,
         attributesType: String
     ) {
         self.timestamp = timestamp
         self.contentState = contentState
-        self.dismissalDate = dismissalDate
         self.alert = alert
         self.attributes = attributes
         self.attributesType = attributesType


### PR DESCRIPTION
A `dismissalDate` can only be set when an update is sent with the `end` event. When setting it while sending with other events (start or update) it has no impact.