### PR TITLE
Add new error reason: BadEnvironmentKeyInToken

### DIFF
--- a/Sources/APNSCore/APNSError.swift
+++ b/Sources/APNSCore/APNSError.swift
@@ -253,8 +253,8 @@ public struct APNSError: Error {
                     return "The server is shutting down"
                 case .badEnvironmentKeyInToken:
                     return "Environment mismatch between key and APNs endpoint"
-                case .unknown:
-                    return "Indicates an error reason that is unknown to `APNSwift`. If you receive this please file an issue so that we can extend the known error reasons"
+                case .unknown(let string):
+                    return "Indicates an error reason that is unknown value \"\(string)\" to `APNSwift`. If you receive this please file an issue so that we can extend the known error reasons"
                 }
             }
         }


### PR DESCRIPTION
This adds support for the `BadEnvironmentKeyInToken` error reason returned by APNs.
The error occurs when an authentication key or token is used with the wrong APNs environment (e.g. production key against sandbox).
Previously this was treated as .unknown.
