### PR TITLE
Fix broadcast "list all channels" to use /all-channels endpoint

### DIFF
--- a/Sources/APNSCore/Broadcast/APNSBroadcastRequest.swift
+++ b/Sources/APNSCore/Broadcast/APNSBroadcastRequest.swift
@@ -46,8 +46,12 @@ public struct APNSBroadcastRequest<Message: Encodable>: Sendable where Message: 
         /// The path for this operation.
         public var path: String {
             switch self {
-            case .create, .delete, .read, .listAll:
+            case .create, .delete, .read:
                 return "/channels"
+            case .listAll:
+                // Apple exposes "read all channels" on a distinct endpoint.
+                // See: https://developer.apple.com/documentation/usernotifications/sending-channel-management-requests-to-apns
+                return "/all-channels"
             }
         }
 

--- a/Sources/APNSTestServer/APNSTestServer.swift
+++ b/Sources/APNSTestServer/APNSTestServer.swift
@@ -25,7 +25,7 @@ import struct Foundation.CharacterSet
 ///
 /// This server supports both:
 /// - **Regular push notifications**: `POST /3/device/{token}`
-/// - **Broadcast channels**: `POST/GET/DELETE /channels[/{id}]`
+/// - **Broadcast channels**: `POST/GET/DELETE /1/apps/{bundleID}/channels` (+ `GET /1/apps/{bundleID}/all-channels`)
 ///
 /// ## Usage
 ///
@@ -141,11 +141,19 @@ public final class APNSTestServer: @unchecked Sendable {
         case (.POST, 4) where components[0] == "1" && components[1] == "apps" && components[3] == "channels":
             return handleCreateChannel(body: body)
 
-        case (.GET, 4) where components[0] == "1" && components[1] == "apps" && components[3] == "channels":
-            if let channelID = headers.first(name: "apns-channel-id") {
-                return handleReadChannel(channelID: channelID)
-            }
+        case (.GET, 4) where components[0] == "1" && components[1] == "apps" && components[3] == "all-channels":
             return handleListChannels()
+
+        case (.GET, 4) where components[0] == "1" && components[1] == "apps" && components[3] == "channels":
+            // Reading a single channel requires the channel ID header. Unlike the real
+            // APNs API, `GET .../channels` without an ID is NOT the list endpoint
+            // (that lives at `.../all-channels`), so reject it rather than silently listing.
+            guard let channelID = headers.first(name: "apns-channel-id") else {
+                var responseHeaders = HTTPHeaders()
+                responseHeaders.add(name: "content-type", value: "application/json")
+                return (.badRequest, responseHeaders, "{\"reason\":\"MissingChannelID\"}")
+            }
+            return handleReadChannel(channelID: channelID)
 
         case (.DELETE, 4) where components[0] == "1" && components[1] == "apps" && components[3] == "channels":
             guard let channelID = headers.first(name: "apns-channel-id") else {

--- a/Tests/APNSTests/Broadcast/APNSBroadcastClientTests.swift
+++ b/Tests/APNSTests/Broadcast/APNSBroadcastClientTests.swift
@@ -153,6 +153,17 @@ final class APNSBroadcastClientTests: XCTestCase {
         XCTAssertEqual(channels.count, 0)
     }
 
+    // MARK: - Operation path contract
+
+    func testOperationPaths() {
+        // Individual channel operations target `/channels`...
+        XCTAssertEqual(APNSBroadcastRequest<EmptyPayload>(operation: .create).operation.path, "/channels")
+        XCTAssertEqual(APNSBroadcastRequest<EmptyPayload>(operation: .read(channelID: "x")).operation.path, "/channels")
+        XCTAssertEqual(APNSBroadcastRequest<EmptyPayload>(operation: .delete(channelID: "x")).operation.path, "/channels")
+        // ...while "read all channels" lives on Apple's distinct `/all-channels` endpoint.
+        XCTAssertEqual(APNSBroadcastRequest<EmptyPayload>(operation: .listAll).operation.path, "/all-channels")
+    }
+
     func testRequestID() async throws {
         let requestID = UUID()
         let channel = APNSBroadcastChannel(messageStoragePolicy: .mostRecentMessageStored)


### PR DESCRIPTION
## Problem

The `.listAll` broadcast operation targeted `/1/apps/{bundleID}/channels`, but Apple's channel-management API exposes "read all channels" on a **distinct endpoint**: `GET /1/apps/{bundleID}/all-channels`. Against real APNs, `readAllChannelIDs()` was hitting the wrong path and would not return the channel list.

This was masked by the mock `APNSTestServer`, which treated any `GET …/channels` without a channel-id header as "list" — mirroring the client's incorrect assumption, so the existing test passed.

Ref: [Sending channel management requests to APNs](https://developer.apple.com/documentation/usernotifications/sending-channel-management-requests-to-apns).

## Changes

- Route `.listAll` to `/all-channels` in `APNSBroadcastRequest.Operation.path`.
- Update `APNSTestServer`:
  - serve `GET /1/apps/{bundleID}/all-channels` for listing
  - require the `apns-channel-id` header on `GET /channels` so it can no longer silently mirror the old behaviour (a regression would now fail the test).
- Add `testOperationPaths` pinning the path contract for create/read/delete/listAll.

## Testing

`swift test --filter APNSBroadcastClientTests` — 10 tests pass, including the existing `testListAllChannels`/`testListAllChannels_empty` now exercising `/all-channels`.