### PR TITLE
Use expirationDurationInSeconds for token refresh window

### DIFF
--- a/Sources/APNSCore/APNSAuthenticationTokenManager.swift
+++ b/Sources/APNSCore/APNSAuthenticationTokenManager.swift
@@ -70,7 +70,7 @@ public final actor APNSAuthenticationTokenManager<Clock: _Concurrency.Clock> whe
             /// First we check if there is a previously generated token
             /// and if that token is still valid.
             if let lastGeneratedToken = lastGeneratedToken,
-               lastGeneratedToken.issuedAt.duration(to: self.clock.now) < .seconds(60 * 55) {
+               lastGeneratedToken.issuedAt.duration(to: self.clock.now) < self.expirationDurationInSeconds {
                 /// The last generated token is still valid
                 return lastGeneratedToken.token
             } else {

--- a/Tests/APNSTests/APNSAuthenticationTokenManagerTests.swift
+++ b/Tests/APNSTests/APNSAuthenticationTokenManagerTests.swift
@@ -98,13 +98,57 @@ final class APNSAuthenticationTokenManagerTests: XCTestCase {
 
     func testTokenIsRefreshed() async throws {
         let token1 = try await tokenManager.nextValidToken
-        
+
         // 56 minutes later
         let temp = clock.now.advanced(by: .init(secondsComponent: 3360, attosecondsComponent: 0))
         clock.now = temp
         let token2 = try await tokenManager.nextValidToken
 
         XCTAssertNotEqual(token1, token2)
+    }
+
+    /// The refresh window is `[0, 55min)`: a token is still considered valid one
+    /// second before 55 minutes, and refreshed at exactly 55 minutes.
+    func testTokenReusedJustBeforeBoundaryAndRefreshedAtBoundary() async throws {
+        let token1 = try await tokenManager.nextValidToken
+
+        // 54:59 — still inside the window, so the cached token is returned.
+        clock.now = clock.now.advanced(by: .init(secondsComponent: 3299, attosecondsComponent: 0))
+        let reused = try await tokenManager.nextValidToken
+        XCTAssertEqual(token1, reused)
+
+        // 55:00 — `duration(to:)` is no longer `< 55min`, so a fresh token is generated.
+        clock.now = clock.now.advanced(by: .init(secondsComponent: 1, attosecondsComponent: 0))
+        let refreshed = try await tokenManager.nextValidToken
+        XCTAssertNotEqual(token1, refreshed)
+    }
+
+    /// A refreshed token must be a well-formed JWT with the correct claims — not merely
+    /// a different string (ECDSA signatures are randomized, so string inequality alone is weak).
+    func testRefreshedTokenIsStructurallyValid() async throws {
+        _ = try await tokenManager.nextValidToken
+
+        clock.now = clock.now.advanced(by: .init(secondsComponent: 3360, attosecondsComponent: 0))
+        let refreshed = try await tokenManager.nextValidToken
+
+        let segments = try XCTUnwrap(refreshed.split(separator: " ").last).split(separator: ".")
+        XCTAssertEqual(segments.count, 3, "Expected a `header.payload.signature` JWT")
+
+        let header = try decodeSegment(segments[0])
+        XCTAssertTrue(header.contains("\"kid\": \"bar\""))
+        XCTAssertTrue(header.contains("\"alg\": \"ES256\""))
+
+        let payload = try decodeSegment(segments[1])
+        XCTAssertTrue(payload.contains("\"iss\": \"foo\""))
+        XCTAssertTrue(payload.contains("\"kid\": \"bar\""))
+    }
+
+    private func decodeSegment(_ segment: Substring) throws -> String {
+        let bytes = try Base64.decode(
+            string: String(segment),
+            options: [.base64UrlAlphabet, .omitPaddingCharacter]
+        )
+        return try XCTUnwrap(String(bytes: bytes, encoding: .utf8))
     }
 }
 


### PR DESCRIPTION
## Problem

`APNSAuthenticationTokenManager` declares `expirationDurationInSeconds = .seconds(60 * 55)` but never reads it — the 55-minute refresh window is hardcoded inline in `nextValidToken`. Changing the named constant would silently have no effect, a latent foot-gun.

Separately, `testTokenIsRefreshed` asserts only that two token strings differ — but ECDSA P256 signatures are randomized, so the strings differ even when the payload is unchanged. The test passes for the wrong reason and proves little about the refresh.

## Changes

- Reference `expirationDurationInSeconds` in the refresh check so it is the single source of truth.
- `testTokenReusedJustBeforeBoundaryAndRefreshedAtBoundary` pins the `[0, 55min)` reuse window at the exact boundary (reused at 54:59, refreshed at 55:00).
- `testRefreshedTokenIsStructurallyValid` decodes the refreshed JWT and asserts the header/claims (`alg`, `kid`, `iss`), instead of relying on string inequality.

## Note

I deliberately did **not** change the JWT `iat` from `DispatchWallTime` to the injected `Clock`: `ContinuousClock` is monotonic and cannot yield epoch seconds, so wall-clock time is the correct source for `iat`, while the injected clock correctly measures the refresh interval.

## Testing

`swift test --filter APNSAuthenticationTokenManagerTests` — 5 tests pass.