### PR TITLE
Tidy broadcast channel model and harden broadcast/error handling

### DIFF
--- a/Sources/APNS/APNSBroadcastClient.swift
+++ b/Sources/APNS/APNSBroadcastClient.swift
@@ -184,7 +184,12 @@ extension APNSBroadcastClient {
         // Handle successful responses
         if response.status == .ok || response.status == .created || response.status == .noContent {
             let body = try await response.body.collect(upTo: 1024 * 1024) // 1MB max
-            let responseBody = try? responseDecoder.decode(ResponseBody.self, from: body)
+            // Operations like create/delete return an empty body, so only decode when there
+            // are bytes to decode — and when there are, surface decode failures rather than
+            // silently dropping a malformed body to `nil`.
+            let responseBody = body.readableBytes > 0
+                ? try responseDecoder.decode(ResponseBody.self, from: body)
+                : nil
             return APNSBroadcastResponse(apnsRequestID: apnsRequestID, channelID: channelID, body: responseBody)
         }
 

--- a/Sources/APNSCore/Broadcast/APNSBroadcastChannel.swift
+++ b/Sources/APNSCore/Broadcast/APNSBroadcastChannel.swift
@@ -28,15 +28,13 @@ public struct APNSBroadcastChannel: Codable, Sendable {
 
     /// Creates a new broadcast channel configuration.
     ///
+    /// `pushType` is fixed to `"LiveActivity"`, the only value APNs currently supports for
+    /// broadcast channels. When decoding a channel from an APNs response, `pushType` is read
+    /// from the payload via the synthesized `Codable` conformance.
+    ///
     /// - Parameter messageStoragePolicy: The storage policy for messages in this channel.
     public init(messageStoragePolicy: APNSBroadcastMessageStoragePolicy) {
         self.messageStoragePolicy = messageStoragePolicy
         self.pushType = "LiveActivity"
-    }
-
-    /// Internal initializer used for decoding responses that include channel ID.
-    public init(messageStoragePolicy: APNSBroadcastMessageStoragePolicy, pushType: String = "LiveActivity") {
-        self.messageStoragePolicy = messageStoragePolicy
-        self.pushType = pushType
     }
 }

--- a/Tests/APNSTests/APNSErrorReasonTests.swift
+++ b/Tests/APNSTests/APNSErrorReasonTests.swift
@@ -1,0 +1,100 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2024 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import APNSCore
+import XCTest
+
+final class APNSErrorReasonTests: XCTestCase {
+    /// Every known APNs reason string paired with the case it must map to.
+    private static let knownReasons: [(APNSError.ErrorReason.Reason, String)] = [
+        (.badCollapseIdentifier, "BadCollapseId"),
+        (.badDeviceToken, "BadDeviceToken"),
+        (.badExpirationDate, "BadExpirationDate"),
+        (.badMessageId, "BadMessageId"),
+        (.badPriority, "BadPriority"),
+        (.badTopic, "BadTopic"),
+        (.deviceTokenNotForTopic, "DeviceTokenNotForTopic"),
+        (.duplicateHeaders, "DuplicateHeaders"),
+        (.idleTimeout, "IdleTimeout"),
+        (.invalidPushType, "InvalidPushType"),
+        (.missingDeviceToken, "MissingDeviceToken"),
+        (.missingTopic, "MissingTopic"),
+        (.payloadEmpty, "PayloadEmpty"),
+        (.topicDisallowed, "TopicDisallowed"),
+        (.badCertificate, "BadCertificate"),
+        (.badCertificateEnvironment, "BadCertificateEnvironment"),
+        (.expiredProviderToken, "ExpiredProviderToken"),
+        (.forbidden, "Forbidden"),
+        (.invalidProviderToken, "InvalidProviderToken"),
+        (.missingProviderToken, "MissingProviderToken"),
+        (.unrelatedKeyIdInToken, "UnrelatedKeyIdInToken"),
+        (.badEnvironmentKeyIdInToken, "BadEnvironmentKeyIdInToken"),
+        (.badPath, "BadPath"),
+        (.methodNotAllowed, "MethodNotAllowed"),
+        (.expiredToken, "ExpiredToken"),
+        (.unregistered, "Unregistered"),
+        (.payloadTooLarge, "PayloadTooLarge"),
+        (.tooManyProviderTokenUpdates, "TooManyProviderTokenUpdates"),
+        (.tooManyRequests, "TooManyRequests"),
+        (.internalServerError, "InternalServerError"),
+        (.serviceUnavailable, "ServiceUnavailable"),
+        (.shutdown, "Shutdown"),
+        (.badEnvironmentKeyInToken, "BadEnvironmentKeyInToken"),
+    ]
+
+    func testEveryKnownReasonRoundTrips() {
+        for (reason, raw) in Self.knownReasons {
+            XCTAssertEqual(reason.rawValue, raw, "rawValue mismatch for \(reason)")
+            XCTAssertEqual(
+                APNSError.ErrorReason.Reason(rawValue: raw),
+                reason,
+                "string \"\(raw)\" did not map back to \(reason)"
+            )
+            XCTAssertFalse(reason.errorDescription.isEmpty, "missing description for \(reason)")
+        }
+    }
+
+    func testUnknownReasonIsPreserved() {
+        let reason = APNSError.ErrorReason.Reason(rawValue: "SomeBrandNewReason")
+        XCTAssertEqual(reason, .unknown("SomeBrandNewReason"))
+        XCTAssertEqual(reason.rawValue, "SomeBrandNewReason")
+        XCTAssertFalse(reason.errorDescription.isEmpty)
+    }
+
+    /// `BadEnvironmentKeyInToken` and `BadEnvironmentKeyIdInToken` differ by a single `Id` —
+    /// guard against the two being conflated.
+    func testSimilarEnvironmentReasonsAreDistinct() {
+        XCTAssertNotEqual(
+            APNSError.ErrorReason.Reason.badEnvironmentKeyInToken,
+            APNSError.ErrorReason.Reason.badEnvironmentKeyIdInToken
+        )
+        XCTAssertEqual(
+            APNSError.ErrorReason.Reason(rawValue: "BadEnvironmentKeyInToken"),
+            .badEnvironmentKeyInToken
+        )
+        XCTAssertEqual(
+            APNSError.ErrorReason.Reason(rawValue: "BadEnvironmentKeyIdInToken"),
+            .badEnvironmentKeyIdInToken
+        )
+    }
+
+    /// Exercises the path `APNSError` actually uses: decoding an `APNSErrorResponse` and
+    /// surfacing the typed reason.
+    func testErrorMapsDecodedResponseReason() throws {
+        let data = Data(#"{"reason":"BadDeviceToken"}"#.utf8)
+        let response = try JSONDecoder().decode(APNSErrorResponse.self, from: data)
+        let error = APNSError(responseStatus: 400, apnsResponse: response)
+        XCTAssertEqual(error.reason, .badDeviceToken)
+    }
+}


### PR DESCRIPTION
## Changes

### `APNSBroadcastChannel`
Drop the redundant second initializer. It was `public`, duplicated `init(messageStoragePolicy:)`, and its `pushType:` parameter was misleading — only `"LiveActivity"` is supported, and decoding a channel from an APNs response goes through the synthesized `Codable` conformance, not this init.

### `APNSBroadcastClient.send`
Previously decoded the success body with `try?`, silently turning a malformed `read`/`listAll` body into `nil`. Now it decodes only when bytes are present and **propagates** decode failures. Empty `create`/`delete` bodies still map to a `nil` body as before.

### Tests
New `APNSErrorReasonTests`:
- round-trips every known reason string ↔ enum case (string mapping had no coverage)
- verifies the `.unknown` fallback preserves the raw string
- guards that `BadEnvironmentKeyInToken` and `BadEnvironmentKeyIdInToken` (differ by `Id`) stay distinct
- covers the decoded-`APNSErrorResponse` → typed reason path

## Testing

`swift test` — 76 tests pass.