### PR TITLE
Fix payload encoding for VoIP, PushToTalk, Complication, FileProvider, and Location notifications

### DIFF
--- a/Sources/APNSCore/Complication/APNSComplicationNotification.swift
+++ b/Sources/APNSCore/Complication/APNSComplicationNotification.swift
@@ -94,6 +94,11 @@ public struct APNSComplicationNotification<Payload: Encodable & Sendable>: APNSM
         self.payload = payload
         self.apnsID = apnsID
     }
+
+    @inlinable
+    public func encode(to encoder: Encoder) throws {
+        try self.payload.encode(to: encoder)
+    }
 }
 
 extension APNSComplicationNotification where Payload == EmptyPayload {

--- a/Sources/APNSCore/FileProvider/APNSFileProviderNotification.swift
+++ b/Sources/APNSCore/FileProvider/APNSFileProviderNotification.swift
@@ -85,6 +85,11 @@ public struct APNSFileProviderNotification<Payload: Encodable & Sendable>: APNSM
         self.payload = payload
         self.apnsID = apnsID
     }
+
+    @inlinable
+    public func encode(to encoder: Encoder) throws {
+        try self.payload.encode(to: encoder)
+    }
 }
 
 extension APNSFileProviderNotification where Payload == EmptyPayload {

--- a/Sources/APNSCore/Location/APNSLocationNotification.swift
+++ b/Sources/APNSCore/Location/APNSLocationNotification.swift
@@ -36,8 +36,8 @@ public struct APNSLocationNotification: APNSMessage {
 
     /// Initializes a new ``APNSLocationNotification``.
     ///
-    /// - Important: Your dynamic payload will get encoded to the root of the JSON payload that is send to APNs.
-    /// It is **important** that you do not encode anything with the key `aps`
+    /// - Important: This notification sends a fixed, minimal body containing only an empty `aps` object;
+    /// it has no dynamic payload.
     ///
     /// - Parameters:
     ///   - priority: The priority of the notification.
@@ -58,8 +58,8 @@ public struct APNSLocationNotification: APNSMessage {
 
     /// Initializes a new ``APNSLocationNotification``.
     ///
-    /// - Important: Your dynamic payload will get encoded to the root of the JSON payload that is send to APNs.
-    /// It is **important** that you do not encode anything with the key `aps`
+    /// - Important: This notification sends a fixed, minimal body containing only an empty `aps` object;
+    /// it has no dynamic payload.
     ///
     /// - Parameters:
     ///   - priority: The priority of the notification.
@@ -74,5 +74,16 @@ public struct APNSLocationNotification: APNSMessage {
         self.priority = priority
         self.topic = topic
         self.apnsID = apnsID
+    }
+
+    internal enum CodingKeys: String, CodingKey {
+        case aps
+    }
+
+    internal struct EmptyAPS: Encodable {}
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(EmptyAPS(), forKey: .aps)
     }
 }

--- a/Sources/APNSCore/PushToTalk/APNSPushToTalkNotification.swift
+++ b/Sources/APNSCore/PushToTalk/APNSPushToTalkNotification.swift
@@ -97,6 +97,11 @@ public struct APNSPushToTalkNotification<Payload: Encodable & Sendable>: APNSMes
         self.payload = payload
         self.apnsID = apnsID
     }
+
+    @inlinable
+    public func encode(to encoder: Encoder) throws {
+        try self.payload.encode(to: encoder)
+    }
 }
 
 extension APNSPushToTalkNotification where Payload == EmptyPayload {

--- a/Sources/APNSCore/VoIP/APNSVoIPNotification.swift
+++ b/Sources/APNSCore/VoIP/APNSVoIPNotification.swift
@@ -97,6 +97,11 @@ public struct APNSVoIPNotification<Payload: Encodable & Sendable>: APNSMessage {
         self.payload = payload
         self.apnsID = apnsID
     }
+
+    @inlinable
+    public func encode(to encoder: Encoder) throws {
+        try self.payload.encode(to: encoder)
+    }
 }
 
 extension APNSVoIPNotification where Payload == EmptyPayload {

--- a/Tests/APNSTests/Complication/APNSComplicationNotificationEncodingTests.swift
+++ b/Tests/APNSTests/Complication/APNSComplicationNotificationEncodingTests.swift
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2022 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import APNSCore
+import XCTest
+
+final class APNSComplicationNotificationEncodingTests: XCTestCase {
+    func testEncode() throws {
+        struct Payload: Encodable {
+            let foo = "bar"
+        }
+        let notification = APNSComplicationNotification(
+            expiration: .immediately,
+            priority: .immediately,
+            topic: "com.example.app.complication",
+            payload: Payload(),
+            apnsID: nil
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(notification)
+
+        let expectedJSONString = """
+        {"foo":"bar"}
+        """
+        let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+        let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
+        XCTAssertEqual(jsonObject1, jsonObject2)
+    }
+
+    func testEncode_whenEmptyPayload() throws {
+        let notification = APNSComplicationNotification(
+            expiration: .immediately,
+            priority: .immediately,
+            appID: "com.example.app"
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(notification)
+
+        let expectedJSONString = """
+        {}
+        """
+        let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+        let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
+        XCTAssertEqual(jsonObject1, jsonObject2)
+    }
+}

--- a/Tests/APNSTests/FileProvider/APNSFileProviderNotificationEncodingTests.swift
+++ b/Tests/APNSTests/FileProvider/APNSFileProviderNotificationEncodingTests.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2022 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import APNSCore
+import XCTest
+
+final class APNSFileProviderNotificationEncodingTests: XCTestCase {
+    func testEncode() throws {
+        struct Payload: Encodable {
+            let foo = "bar"
+        }
+        let notification = APNSFileProviderNotification(
+            expiration: .immediately,
+            topic: "com.example.app.pushkit.fileprovider",
+            payload: Payload(),
+            apnsID: nil
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(notification)
+
+        let expectedJSONString = """
+        {"foo":"bar"}
+        """
+        let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+        let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
+        XCTAssertEqual(jsonObject1, jsonObject2)
+    }
+
+    func testEncode_whenEmptyPayload() throws {
+        let notification = APNSFileProviderNotification(
+            expiration: .immediately,
+            appID: "com.example.app"
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(notification)
+
+        let expectedJSONString = """
+        {}
+        """
+        let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+        let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
+        XCTAssertEqual(jsonObject1, jsonObject2)
+    }
+}

--- a/Tests/APNSTests/Location/APNSLocationNotificationTests.swift
+++ b/Tests/APNSTests/Location/APNSLocationNotificationTests.swift
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2022 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import APNSCore
+import XCTest
+
+final class APNSLocationNotificationTests: XCTestCase {
+    func testAppID() {
+        let locationNotification = APNSLocationNotification(
+            priority: .immediately,
+            appID: "com.example.app"
+        )
+
+        XCTAssertEqual(locationNotification.topic, "com.example.app.location-query")
+    }
+
+    func testEncode() throws {
+        let notification = APNSLocationNotification(
+            priority: .immediately,
+            topic: "com.example.app.location-query",
+            apnsID: nil
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(notification)
+
+        let expectedJSONString = """
+        {"aps":{}}
+        """
+        let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+        let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
+        XCTAssertEqual(jsonObject1, jsonObject2)
+    }
+}

--- a/Tests/APNSTests/PushToTalk/APNSPushToTalkNotificationEncodingTests.swift
+++ b/Tests/APNSTests/PushToTalk/APNSPushToTalkNotificationEncodingTests.swift
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2022 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import APNSCore
+import XCTest
+
+final class APNSPushToTalkNotificationEncodingTests: XCTestCase {
+    func testEncode() throws {
+        struct Payload: Encodable {
+            let foo = "bar"
+        }
+        let notification = APNSPushToTalkNotification(
+            expiration: .immediately,
+            priority: .immediately,
+            topic: "com.example.app.voip-ptt",
+            payload: Payload(),
+            apnsID: nil
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(notification)
+
+        let expectedJSONString = """
+        {"foo":"bar"}
+        """
+        let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+        let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
+        XCTAssertEqual(jsonObject1, jsonObject2)
+    }
+
+    func testEncode_whenEmptyPayload() throws {
+        let notification = APNSPushToTalkNotification(
+            expiration: .immediately,
+            priority: .immediately,
+            appID: "com.example.app"
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(notification)
+
+        let expectedJSONString = """
+        {}
+        """
+        let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+        let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
+        XCTAssertEqual(jsonObject1, jsonObject2)
+    }
+}

--- a/Tests/APNSTests/VoIP/APNSVoIPNotificationEncodingTests.swift
+++ b/Tests/APNSTests/VoIP/APNSVoIPNotificationEncodingTests.swift
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2022 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import APNSCore
+import XCTest
+
+final class APNSVoIPNotificationEncodingTests: XCTestCase {
+    func testEncode() throws {
+        struct Payload: Encodable {
+            let foo = "bar"
+        }
+        let notification = APNSVoIPNotification(
+            expiration: .immediately,
+            priority: .immediately,
+            topic: "com.example.app.voip",
+            payload: Payload(),
+            apnsID: nil
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(notification)
+
+        let expectedJSONString = """
+        {"foo":"bar"}
+        """
+        let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+        let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
+        XCTAssertEqual(jsonObject1, jsonObject2)
+    }
+
+    func testEncode_whenEmptyPayload() throws {
+        let notification = APNSVoIPNotification(
+            expiration: .immediately,
+            priority: .immediately,
+            appID: "com.example.app"
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(notification)
+
+        let expectedJSONString = """
+        {}
+        """
+        let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+        let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
+        XCTAssertEqual(jsonObject1, jsonObject2)
+    }
+}


### PR DESCRIPTION
These five notification types had no custom `encode(to:)`, so the synthesized `Encodable` sent header metadata (`topic`, `expiration`, `priority`, `apnsID`) in the HTTP body and nested the user payload under `"payload"` instead of the root — contradicting each type's own documentation.

- VoIP/PushToTalk/Complication/FileProvider now encode only the user payload at the root (same pattern as `APNSBackgroundNotification`).
- Location (which has no payload) now sends a minimal `{"aps":{}}` body; Apple documents no body shape for location pushes.
- Adds exact-JSON encoding tests for all five types, plus the previously missing Location topic-suffix test.