### PR TITLE
Expand test coverage and remove low-value tests

### DIFF
--- a/Tests/APNSTests/APNSAuthenticationTokenManagerTests.swift
+++ b/Tests/APNSTests/APNSAuthenticationTokenManagerTests.swift
@@ -88,28 +88,6 @@ final class APNSAuthenticationTokenManagerTests: XCTestCase {
         XCTAssertEqual(Double(payload.iat), now, accuracy: 5)
     }
     
-        func testTokenIsReused() async throws {
-   
-            let token1 = try await tokenManager.nextValidToken
-            // 48 minutes later
-            let temp = clock.now.advanced(by: .init(secondsComponent: 2880, attosecondsComponent: 0))
-            clock.now = temp
-            let token2 = try await tokenManager.nextValidToken
-    
-            XCTAssertEqual(token1, token2)
-        }
-
-    func testTokenIsRefreshed() async throws {
-        let token1 = try await tokenManager.nextValidToken
-
-        // 56 minutes later
-        let temp = clock.now.advanced(by: .init(secondsComponent: 3360, attosecondsComponent: 0))
-        clock.now = temp
-        let token2 = try await tokenManager.nextValidToken
-
-        XCTAssertNotEqual(token1, token2)
-    }
-
     /// The refresh window is `[0, 55min)`: a token is still considered valid one
     /// second before 55 minutes, and refreshed at exactly 55 minutes.
     func testTokenReusedJustBeforeBoundaryAndRefreshedAtBoundary() async throws {

--- a/Tests/APNSTests/APNSClientIntegrationTests.swift
+++ b/Tests/APNSTests/APNSClientIntegrationTests.swift
@@ -50,6 +50,8 @@ final class APNSClientIntegrationTests: XCTestCase {
     override func tearDown() async throws {
         try await client?.shutdown()
         try await server?.shutdown()
+        client = nil
+        server = nil
         try await super.tearDown()
     }
 
@@ -108,6 +110,10 @@ final class APNSClientIntegrationTests: XCTestCase {
         XCTAssertEqual(sent.count, 1)
         XCTAssertEqual(sent[0].deviceToken, "1111111111111111111111111111111111111111111111111111111111111111")
         XCTAssertEqual(sent[0].pushType, "alert")
+
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: sent[0].payload) as? NSDictionary)
+        let aps = try XCTUnwrap(json["aps"] as? NSDictionary)
+        XCTAssertEqual(aps["badge"] as? Int, 5)
     }
 
     func testSendAlertNotification_withSound() async throws {
@@ -128,6 +134,10 @@ final class APNSClientIntegrationTests: XCTestCase {
         let sent = server.getSentNotifications()
         XCTAssertEqual(sent.count, 1)
         XCTAssertEqual(sent[0].deviceToken, "2222222222222222222222222222222222222222222222222222222222222222")
+
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: sent[0].payload) as? NSDictionary)
+        let aps = try XCTUnwrap(json["aps"] as? NSDictionary)
+        XCTAssertEqual(aps["sound"] as? String, "default")
     }
 
     // MARK: - Background Notifications
@@ -222,11 +232,177 @@ final class APNSClientIntegrationTests: XCTestCase {
         XCTAssertEqual(sent[0].pushType, "complication")
     }
 
+    // MARK: - Live Activity Notifications
+
+    func testSendLiveActivityNotification() async throws {
+        struct ContentState: Codable {
+            let value: String
+        }
+
+        let notification = APNSLiveActivityNotification(
+            expiration: .immediately,
+            priority: .immediately,
+            appID: "com.example.app",
+            contentState: ContentState(value: "update-value"),
+            event: .update,
+            timestamp: 1_234_567_890
+        )
+
+        _ = try await client.sendLiveActivityNotification(
+            notification,
+            deviceToken: "7777777777777777777777777777777777777777777777777777777777777777"
+        )
+
+        let sent = try XCTUnwrap(server.getSentNotifications().first)
+        XCTAssertEqual(sent.pushType, "liveactivity")
+        XCTAssertEqual(sent.topic, "com.example.app.push-type.liveactivity")
+
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: sent.payload) as? NSDictionary)
+        let aps = try XCTUnwrap(json["aps"] as? NSDictionary)
+        XCTAssertEqual(aps["event"] as? String, "update")
+        XCTAssertNotNil(aps["timestamp"])
+        XCTAssertNotNil(aps["content-state"])
+    }
+
+    func testSendStartLiveActivityNotification() async throws {
+        struct Attributes: Codable {}
+        struct ContentState: Codable {
+            let value: String
+        }
+
+        let notification = APNSStartLiveActivityNotification(
+            expiration: .immediately,
+            priority: .immediately,
+            appID: "com.example.app",
+            contentState: ContentState(value: "start-value"),
+            timestamp: 1_234_567_890,
+            attributes: Attributes(),
+            attributesType: "MyActivityAttributes",
+            alert: .init(title: .raw("Live Activity Started"))
+        )
+
+        _ = try await client.sendStartLiveActivityNotification(
+            notification,
+            pushToStartToken: "8888888888888888888888888888888888888888888888888888888888888888"
+        )
+
+        let sent = try XCTUnwrap(server.getSentNotifications().first)
+        XCTAssertEqual(sent.pushType, "liveactivity")
+        XCTAssertEqual(sent.topic, "com.example.app.push-type.liveactivity")
+
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: sent.payload) as? NSDictionary)
+        let aps = try XCTUnwrap(json["aps"] as? NSDictionary)
+        XCTAssertEqual(aps["event"] as? String, "start")
+        XCTAssertEqual(aps["attributes-type"] as? String, "MyActivityAttributes")
+    }
+
+    // MARK: - Push To Talk Notifications
+
+    func testSendPushToTalkNotification() async throws {
+        struct Payload: Encodable {
+            let activeSpeaker = "Alice"
+        }
+
+        let notification = APNSPushToTalkNotification(
+            appID: "com.example.app",
+            payload: Payload()
+        )
+
+        _ = try await client.sendPushToTalkNotification(
+            notification,
+            deviceToken: "9999999999999999999999999999999999999999999999999999999999999999"
+        )
+
+        let sent = try XCTUnwrap(server.getSentNotifications().first)
+        XCTAssertEqual(sent.pushType, "pushtotalk")
+        XCTAssertEqual(sent.topic, "com.example.app.voip-ptt")
+        XCTAssertEqual(sent.deviceToken, "9999999999999999999999999999999999999999999999999999999999999999")
+        // payload shape asserted in encode tests (see PR1)
+    }
+
+    // MARK: - Widgets Notifications
+
+    func testSendWidgetsNotification() async throws {
+        let notification = APNSWidgetsNotification(appID: "com.example.app")
+
+        _ = try await client.sendWidgetsNotification(
+            notification: notification,
+            deviceToken: "aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111"
+        )
+
+        let sent = try XCTUnwrap(server.getSentNotifications().first)
+        XCTAssertEqual(sent.pushType, "widgets")
+        XCTAssertEqual(sent.topic, "com.example.app.push-type.widgets")
+
+        let expectedJSONString = """
+        {"aps":{"content-changed":true}}
+        """
+        let jsonObject1 = try JSONSerialization.jsonObject(with: sent.payload) as! NSDictionary
+        let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
+        XCTAssertEqual(jsonObject1, jsonObject2)
+    }
+
+    // MARK: - Location Notifications
+
+    func testSendLocationNotification() async throws {
+        let notification = APNSLocationNotification(
+            priority: .immediately,
+            appID: "com.example.app"
+        )
+
+        _ = try await client.sendLocationNotification(
+            notification,
+            deviceToken: "bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222"
+        )
+
+        let sent = try XCTUnwrap(server.getSentNotifications().first)
+        XCTAssertEqual(sent.pushType, "location")
+        XCTAssertEqual(sent.topic, "com.example.app.location-query")
+        // sendLocationNotification forces expiration to `.none`, so no header should be sent.
+        XCTAssertNil(sent.expiration)
+    }
+
+    // MARK: - Alert Notification Header Variants
+
+    func testSendAlert_consideringDevicePower() async throws {
+        let notification = APNSAlertNotification(
+            alert: .init(title: .raw("Power Test")),
+            expiration: .immediately,
+            priority: .consideringDevicePower,
+            topic: "com.example.app",
+            payload: EmptyPayload()
+        )
+
+        _ = try await client.sendAlertNotification(
+            notification,
+            deviceToken: "cccc3333cccc3333cccc3333cccc3333cccc3333cccc3333cccc3333cccc3333"
+        )
+
+        let sent = try XCTUnwrap(server.getSentNotifications().first)
+        XCTAssertEqual(sent.priority, "5")
+    }
+
+    func testSendAlert_noExpirationHeaderWhenNone() async throws {
+        let notification = APNSAlertNotification(
+            alert: .init(title: .raw("Expiration None Test")),
+            expiration: .none,
+            priority: .immediately,
+            topic: "com.example.app",
+            payload: EmptyPayload()
+        )
+
+        _ = try await client.sendAlertNotification(
+            notification,
+            deviceToken: "dddd4444dddd4444dddd4444dddd4444dddd4444dddd4444dddd4444dddd4444"
+        )
+
+        let sent = try XCTUnwrap(server.getSentNotifications().first)
+        XCTAssertNil(sent.expiration)
+    }
+
     // MARK: - Multiple Notifications
 
     func testSendMultipleNotifications() async throws {
-        server.clearSentNotifications()
-
         // Send 3 different notifications
         let alert = APNSAlertNotification(
             alert: .init(title: .raw("Alert")),

--- a/Tests/APNSTests/APNSEnvironmentTests.swift
+++ b/Tests/APNSTests/APNSEnvironmentTests.swift
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2024 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import APNSCore
+import XCTest
+
+final class APNSEnvironmentTests: XCTestCase {
+    func testProduction() {
+        XCTAssertEqual(APNSEnvironment.production.url, "https://api.push.apple.com")
+        XCTAssertEqual(APNSEnvironment.production.port, 443)
+        XCTAssertEqual(APNSEnvironment.production.absoluteURL, "https://api.push.apple.com:443/3/device")
+    }
+
+    func testDevelopment() {
+        XCTAssertEqual(APNSEnvironment.development.url, "https://api.development.push.apple.com")
+        XCTAssertEqual(APNSEnvironment.development.port, 443)
+        XCTAssertEqual(APNSEnvironment.development.absoluteURL, "https://api.development.push.apple.com:443/3/device")
+    }
+
+    @available(*, deprecated, message: "Intentionally exercising the deprecated `.sandbox` alias.")
+    func testSandbox_isAliasForDevelopment() {
+        // `.sandbox` is deprecated in favor of `.development`, but must remain behaviorally identical.
+        let sandbox = APNSEnvironment.sandbox
+        XCTAssertEqual(sandbox.url, APNSEnvironment.development.url)
+        XCTAssertEqual(sandbox.port, APNSEnvironment.development.port)
+        XCTAssertEqual(sandbox.absoluteURL, APNSEnvironment.development.absoluteURL)
+    }
+
+    func testCustom_composesURLAndPort() {
+        let custom = APNSEnvironment.custom(url: "http://127.0.0.1", port: 8080)
+        XCTAssertEqual(custom.url, "http://127.0.0.1")
+        XCTAssertEqual(custom.port, 8080)
+        XCTAssertEqual(custom.absoluteURL, "http://127.0.0.1:8080/3/device")
+    }
+
+    func testCustom_defaultsPortTo443() {
+        let custom = APNSEnvironment.custom(url: "https://example.com")
+        XCTAssertEqual(custom.port, 443)
+        XCTAssertEqual(custom.absoluteURL, "https://example.com:443/3/device")
+    }
+}
+
+final class APNSBroadcastEnvironmentTests: XCTestCase {
+    func testProduction() {
+        XCTAssertEqual(APNSBroadcastEnvironment.production.url, "https://api-manage-broadcast.push.apple.com")
+        XCTAssertEqual(APNSBroadcastEnvironment.production.port, 2196)
+    }
+
+    func testDevelopment() {
+        XCTAssertEqual(APNSBroadcastEnvironment.development.url, "https://api-manage-broadcast.sandbox.push.apple.com")
+        XCTAssertEqual(APNSBroadcastEnvironment.development.port, 2195)
+    }
+
+    func testCustom_composesURLAndPort() {
+        let custom = APNSBroadcastEnvironment.custom(url: "http://127.0.0.1", port: 9090)
+        XCTAssertEqual(custom.url, "http://127.0.0.1")
+        XCTAssertEqual(custom.port, 9090)
+    }
+
+    func testCustom_defaultsPortTo443() {
+        let custom = APNSBroadcastEnvironment.custom(url: "https://example.com")
+        XCTAssertEqual(custom.port, 443)
+    }
+}

--- a/Tests/APNSTests/APNSRequestTests.swift
+++ b/Tests/APNSTests/APNSRequestTests.swift
@@ -1,0 +1,117 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2024 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import APNSCore
+import XCTest
+
+private struct TestMessage: APNSMessage {}
+
+/// Direct coverage of ``APNSCore.APNSRequest.headers``, which is the URLSession client's
+/// entire header contract.
+final class APNSRequestTests: XCTestCase {
+    func testHeaders_fullRequestEmitsAllHeaders() throws {
+        let apnsID = UUID()
+        let request = APNSRequest(
+            message: TestMessage(),
+            deviceToken: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            pushType: .alert,
+            expiration: .timeIntervalSince1970InSeconds(1_234_567_890),
+            priority: .immediately,
+            apnsID: apnsID,
+            topic: "com.example.app",
+            collapseID: "collapse-123"
+        )
+
+        let headers = request.headers
+
+        XCTAssertEqual(headers["apns-id"], apnsID.uuidString.lowercased())
+        XCTAssertEqual(headers["apns-expiration"], "1234567890")
+        XCTAssertEqual(headers["apns-priority"], "10")
+        XCTAssertEqual(headers["apns-topic"], "com.example.app")
+        XCTAssertEqual(headers["apns-collapse-id"], "collapse-123")
+        XCTAssertEqual(headers["apns-push-type"], "alert")
+    }
+
+    func testHeaders_apnsIDIsLowercased() throws {
+        // UUID() can produce uppercase hex; the header value must always be lowercased.
+        let apnsID = UUID(uuidString: "ABCDEF12-3456-7890-ABCD-EF1234567890")!
+        let request = APNSRequest(
+            message: TestMessage(),
+            deviceToken: "token",
+            pushType: .alert,
+            expiration: nil,
+            priority: nil,
+            apnsID: apnsID,
+            topic: nil,
+            collapseID: nil
+        )
+
+        XCTAssertEqual(request.headers["apns-id"], "abcdef12-3456-7890-abcd-ef1234567890")
+    }
+
+    func testHeaders_minimalRequestOmitsOptionalHeaders() throws {
+        let request = APNSRequest(
+            message: TestMessage(),
+            deviceToken: "token",
+            pushType: .background,
+            expiration: nil,
+            priority: nil,
+            apnsID: nil,
+            topic: nil,
+            collapseID: nil
+        )
+
+        let headers = request.headers
+
+        XCTAssertEqual(headers["apns-push-type"], "background")
+        XCTAssertNil(headers["apns-id"])
+        XCTAssertNil(headers["apns-expiration"])
+        XCTAssertNil(headers["apns-priority"])
+        XCTAssertNil(headers["apns-topic"])
+        XCTAssertNil(headers["apns-collapse-id"])
+    }
+
+    func testHeaders_expirationImmediatelyIsZero() throws {
+        let request = APNSRequest(
+            message: TestMessage(),
+            deviceToken: "token",
+            pushType: .alert,
+            expiration: .immediately,
+            priority: nil,
+            apnsID: nil,
+            topic: nil,
+            collapseID: nil
+        )
+
+        XCTAssertEqual(request.headers["apns-expiration"], "0")
+    }
+
+    func testHeaders_expirationNoneOmitsHeader() throws {
+        // `APNSNotificationExpiration.none` (as opposed to a `nil` `APNSRequest.expiration`)
+        // must also omit the header.
+        let noneExpiration: APNSNotificationExpiration? = APNSNotificationExpiration.none
+        let request = APNSRequest(
+            message: TestMessage(),
+            deviceToken: "token",
+            pushType: .alert,
+            expiration: noneExpiration,
+            priority: nil,
+            apnsID: nil,
+            topic: nil,
+            collapseID: nil
+        )
+
+        XCTAssertNil(request.headers["apns-expiration"])
+    }
+}

--- a/Tests/APNSTests/Alert/APNSAlertNotificationTests.swift
+++ b/Tests/APNSTests/Alert/APNSAlertNotificationTests.swift
@@ -137,4 +137,88 @@ final class APNSAlertNotificationTests: XCTestCase {
         let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
         XCTAssertEqual(jsonObject1, jsonObject2)
     }
+
+    func testEncode_whenLocalizedTitleAndBody() throws {
+        struct Payload: Encodable {
+            let foo = "bar"
+        }
+        let notification = APNSAlertNotification(
+            alert: .init(
+                title: .localized(key: "title-key", arguments: ["title-arg"]),
+                body: .localized(key: "body-key", arguments: ["body-arg1", "body-arg2"])
+            ),
+            expiration: .immediately,
+            priority: .immediately,
+            topic: "",
+            payload: Payload()
+        )
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(notification)
+
+        let expectedJSONString = """
+        {"foo":"bar","aps":{"alert":{"title-loc-key":"title-key","title-loc-args":["title-arg"],"loc-key":"body-key","loc-args":["body-arg1","body-arg2"]}}}
+        """
+        let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+        let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
+        XCTAssertEqual(jsonObject1, jsonObject2)
+
+        let alertDict = try XCTUnwrap((jsonObject1["aps"] as? NSDictionary)?["alert"] as? NSDictionary)
+        XCTAssertNil(alertDict["title"])
+        XCTAssertNil(alertDict["body"])
+    }
+
+    func testEncode_whenFileNameSound() throws {
+        struct Payload: Encodable {
+            let foo = "bar"
+        }
+        let notification = APNSAlertNotification(
+            alert: .init(title: .raw("title")),
+            expiration: .immediately,
+            priority: .immediately,
+            topic: "",
+            payload: Payload(),
+            sound: .fileName("horn.aiff")
+        )
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(notification)
+
+        let expectedJSONString = """
+        {"foo":"bar","aps":{"alert":{"title":"title"},"sound":"horn.aiff"}}
+        """
+        let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+        let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
+        XCTAssertEqual(jsonObject1, jsonObject2)
+
+        let aps = try XCTUnwrap(jsonObject1["aps"] as? NSDictionary)
+        XCTAssertEqual(aps["sound"] as? String, "horn.aiff")
+    }
+
+    func testEncode_interruptionLevels() throws {
+        struct Payload: Encodable {
+            let foo = "bar"
+        }
+
+        let levels: [(APNSAlertNotificationInterruptionLevel, String)] = [
+            (.passive, "passive"),
+            (.active, "active"),
+            (.timeSensitive, "time-sensitive"),
+        ]
+
+        for (level, expectedRawValue) in levels {
+            let notification = APNSAlertNotification(
+                alert: .init(title: .raw("title")),
+                expiration: .immediately,
+                priority: .immediately,
+                topic: "",
+                payload: Payload(),
+                interruptionLevel: level
+            )
+            let encoder = JSONEncoder()
+            let data = try encoder.encode(notification)
+
+            let jsonObject = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+            let aps = try XCTUnwrap(jsonObject["aps"] as? NSDictionary)
+            XCTAssertEqual(aps["interruption-level"] as? String, expectedRawValue)
+        }
+    }
 }

--- a/Tests/APNSTests/Background/APNSBackgroundNotificationTests.swift
+++ b/Tests/APNSTests/Background/APNSBackgroundNotificationTests.swift
@@ -38,7 +38,7 @@ final class APNSBackgroundNotificationTests: XCTestCase {
         XCTAssertEqual(jsonObject1, jsonObject2)
     }
 
-    func testEnode_whenAPSKeyInPayload() throws {
+    func testEncode_whenAPSKeyInPayload() throws {
         struct Payload: Encodable {
             let aps = "foo"
         }

--- a/Tests/APNSTests/Broadcast/APNSBroadcastChannelListTests.swift
+++ b/Tests/APNSTests/Broadcast/APNSBroadcastChannelListTests.swift
@@ -40,17 +40,4 @@ final class APNSBroadcastChannelListTests: XCTestCase {
 
         XCTAssertEqual(channelList.channels.count, 0)
     }
-
-    func testEncode() throws {
-        let channelList = APNSBroadcastChannelList(channels: ["channel-1", "channel-2"])
-        let encoder = JSONEncoder()
-        let data = try encoder.encode(channelList)
-
-        let expectedJSONString = """
-        {"channels":["channel-1","channel-2"]}
-        """
-        let jsonObject1 = try JSONSerialization.jsonObject(with: data) as! NSDictionary
-        let jsonObject2 = try JSONSerialization.jsonObject(with: expectedJSONString.data(using: .utf8)!) as! NSDictionary
-        XCTAssertEqual(jsonObject1, jsonObject2)
-    }
 }

--- a/Tests/APNSTests/Broadcast/APNSBroadcastClientTests.swift
+++ b/Tests/APNSTests/Broadcast/APNSBroadcastClientTests.swift
@@ -49,6 +49,8 @@ final class APNSBroadcastClientTests: XCTestCase {
     override func tearDown() async throws {
         try await client?.shutdown()
         try await server?.shutdown()
+        client = nil
+        server = nil
         try await super.tearDown()
     }
 
@@ -169,8 +171,12 @@ final class APNSBroadcastClientTests: XCTestCase {
         let channel = APNSBroadcastChannel(messageStoragePolicy: .mostRecentMessageStored)
         let response = try await client.create(channel: channel, apnsRequestID: requestID)
 
-        // The server returns its own request ID, but we verify the client can handle custom IDs
-        XCTAssertNotNil(response.apnsRequestID)
+        // The server echoes back the `apns-request-id` header the client sent.
+        let requests = server.getBroadcastRequests()
+        let createRequest = try XCTUnwrap(requests.first { $0.method == "POST" })
+        XCTAssertEqual(createRequest.apnsRequestID, requestID.uuidString.lowercased())
+
+        XCTAssertEqual(response.apnsRequestID, requestID)
     }
 
     // MARK: - Helper


### PR DESCRIPTION
Stacked on #246; will be retargeted to main once it merges.

- First-ever wire tests for liveactivity (update + start), pushtotalk, widgets, and location through a real client; priority-5 and no-expiration header checks.
- Alert encode variants: localized title/body keys, `.fileName` sound, all interruption levels.
- Direct unit tests for `APNSRequest.headers` (the URLSession client's entire header contract) and `APNSEnvironment`/`APNSBroadcastEnvironment` URL composition.
- `withBadge`/`withSound` tests now actually decode and assert the payload; `testRequestID` asserts the echoed `apns-request-id`.
- Removes tests that couldn't fail meaningfully (channel-list encode, two token-window tests subsumed by the boundary test); fixes a test-name typo and tearDown hygiene.