### PR TITLE
Return typed APNSError for undecodable error bodies and add broadcast error reasons

### DIFF
--- a/Sources/APNS/APNSBroadcastClient.swift
+++ b/Sources/APNS/APNSBroadcastClient.swift
@@ -193,16 +193,18 @@ extension APNSBroadcastClient {
             return APNSBroadcastResponse(apnsRequestID: apnsRequestID, channelID: channelID, body: responseBody)
         }
 
-        // Handle error responses
-        let body = try await response.body.collect(upTo: 1024)
-        let errorResponse = try responseDecoder.decode(APNSErrorResponse.self, from: body)
+        // Handle error responses. An empty body, non-JSON body, or a body exceeding the
+        // collection limit must still surface as a typed `APNSError` (with `reason: nil`)
+        // rather than a raw decoding error, so the caller never loses the status code and headers.
+        let errorBody = try? await response.body.collect(upTo: 1024)
+        let errorResponse = errorBody.flatMap { try? responseDecoder.decode(APNSErrorResponse.self, from: $0) }
 
         let error = APNSError(
             responseStatus: Int(response.status.code),
             apnsID: nil,
             apnsUniqueID: nil,
             apnsResponse: errorResponse,
-            timestamp: errorResponse.timestampInSeconds.flatMap { Date(timeIntervalSince1970: $0) }
+            timestamp: errorResponse?.timestampInSeconds.flatMap { Date(timeIntervalSince1970: $0) }
         )
 
         throw error

--- a/Sources/APNS/APNSClient.swift
+++ b/Sources/APNS/APNSClient.swift
@@ -187,15 +187,18 @@ extension APNSClient {
             return APNSResponse(apnsID: apnsID, apnsUniqueID: apnsUniqueID)
         }
 
-        let body = try await response.body.collect(upTo: 1024)
-        let errorResponse = try responseDecoder.decode(APNSErrorResponse.self, from: body)
+        // An empty body, non-JSON body, or a body exceeding the collection limit must still
+        // surface as a typed `APNSError` (with `reason: nil`) rather than a raw decoding error,
+        // so the caller never loses the status code and headers.
+        let body = try? await response.body.collect(upTo: 1024)
+        let errorResponse = body.flatMap { try? responseDecoder.decode(APNSErrorResponse.self, from: $0) }
 
         let error = APNSError(
             responseStatus: Int(response.status.code),
             apnsID: apnsID,
             apnsUniqueID: apnsUniqueID,
             apnsResponse: errorResponse,
-            timestamp: errorResponse.timestampInSeconds.flatMap { Date(timeIntervalSince1970: $0) }
+            timestamp: errorResponse?.timestampInSeconds.flatMap { Date(timeIntervalSince1970: $0) }
         )
 
         throw error

--- a/Sources/APNSCore/APNSError.swift
+++ b/Sources/APNSCore/APNSError.swift
@@ -63,6 +63,15 @@ public struct APNSError: Error {
             case serviceUnavailable
             case shutdown
             case badEnvironmentKeyInToken
+            case featureNotEnabled
+            case missingChannelId
+            case badChannelId
+            case channelNotRegistered
+            case badRequestParams
+            case badRequestPayload
+            case missingPushType
+            case cannotCreateChannelConfig
+            case topicMismatch
             case unknown(String)
             
             public init(rawValue: RawValue) {
@@ -133,6 +142,24 @@ public struct APNSError: Error {
                     self = .shutdown
                 case "BadEnvironmentKeyInToken":
                     self = .badEnvironmentKeyInToken
+                case "FeatureNotEnabled":
+                    self = .featureNotEnabled
+                case "MissingChannelId":
+                    self = .missingChannelId
+                case "BadChannelId":
+                    self = .badChannelId
+                case "ChannelNotRegistered":
+                    self = .channelNotRegistered
+                case "BadRequestParams":
+                    self = .badRequestParams
+                case "BadRequestPayload":
+                    self = .badRequestPayload
+                case "MissingPushType":
+                    self = .missingPushType
+                case "CannotCreateChannelConfig":
+                    self = .cannotCreateChannelConfig
+                case "TopicMismatch":
+                    self = .topicMismatch
                 default:
                     self = .unknown(rawValue)
                 }
@@ -206,6 +233,24 @@ public struct APNSError: Error {
                     return "Shutdown"
                 case .badEnvironmentKeyInToken:
                     return "BadEnvironmentKeyInToken"
+                case .featureNotEnabled:
+                    return "FeatureNotEnabled"
+                case .missingChannelId:
+                    return "MissingChannelId"
+                case .badChannelId:
+                    return "BadChannelId"
+                case .channelNotRegistered:
+                    return "ChannelNotRegistered"
+                case .badRequestParams:
+                    return "BadRequestParams"
+                case .badRequestPayload:
+                    return "BadRequestPayload"
+                case .missingPushType:
+                    return "MissingPushType"
+                case .cannotCreateChannelConfig:
+                    return "CannotCreateChannelConfig"
+                case .topicMismatch:
+                    return "TopicMismatch"
                 case .unknown(let string):
                     return string
                 }
@@ -279,6 +324,24 @@ public struct APNSError: Error {
                     return "The server is shutting down"
                 case .badEnvironmentKeyInToken:
                     return "Environment mismatch between key and APNs endpoint"
+                case .featureNotEnabled:
+                    return "The broadcast push feature isn't enabled for this topic"
+                case .missingChannelId:
+                    return "The request didn't include the apns-channel-id header"
+                case .badChannelId:
+                    return "The channel ID wasn't properly encoded or exceeds the maximum allowed length"
+                case .channelNotRegistered:
+                    return "The specified channel ID doesn't exist or is no longer registered"
+                case .badRequestParams:
+                    return "The request contains an unrecognizable attribute in the JSON payload"
+                case .badRequestPayload:
+                    return "The request payload couldn't be parsed as JSON"
+                case .missingPushType:
+                    return "The request didn't specify an apns-push-type"
+                case .cannotCreateChannelConfig:
+                    return "The maximum number of channels has been reached; a new channel configuration can't be created"
+                case .topicMismatch:
+                    return "The bundle IDs in the provider token or certificate don't include the specified topic"
                 case .unknown(let string):
                     return "Indicates an error reason that is unknown value \"\(string)\" to `APNSwift`. If you receive this please file an issue so that we can extend the known error reasons"
                 }
@@ -425,8 +488,45 @@ public struct APNSError: Error {
             return .init(_reason: .shutdown)
         }
 
+        @available(*, deprecated, message: "Not a documented APNs error reason; see badEnvironmentKeyIdInToken.")
         public static var badEnvironmentKeyInToken: Self {
             return .init(_reason: .badEnvironmentKeyInToken)
+        }
+
+        public static var featureNotEnabled: Self {
+            return .init(_reason: .featureNotEnabled)
+        }
+
+        public static var missingChannelId: Self {
+            return .init(_reason: .missingChannelId)
+        }
+
+        public static var badChannelId: Self {
+            return .init(_reason: .badChannelId)
+        }
+
+        public static var channelNotRegistered: Self {
+            return .init(_reason: .channelNotRegistered)
+        }
+
+        public static var badRequestParams: Self {
+            return .init(_reason: .badRequestParams)
+        }
+
+        public static var badRequestPayload: Self {
+            return .init(_reason: .badRequestPayload)
+        }
+
+        public static var missingPushType: Self {
+            return .init(_reason: .missingPushType)
+        }
+
+        public static var cannotCreateChannelConfig: Self {
+            return .init(_reason: .cannotCreateChannelConfig)
+        }
+
+        public static var topicMismatch: Self {
+            return .init(_reason: .topicMismatch)
         }
 
         init(_reason: APNSError.ErrorReason.Reason) {
@@ -446,14 +546,15 @@ public struct APNSError: Error {
     /// A unique ID for the notification used for development, as determined by the APNs servers.
     ///
     /// In the development or sandbox environement, this value can be used to look up information about notifications on the [Push Notifications Console](https://icloud.developer.apple.com/dashboard/notifications). This value is not provided in the production environement.
-    public var apnsUniqueID: UUID?
+    public let apnsUniqueID: UUID?
 
     /// The error code indicating the reason for the failure.
     public let reason: ErrorReason?
 
     /// The date at which APNs confirmed the token was no longer valid for the topic.
     ///
-    /// This is only set when the error reason is `unregistered`.
+    /// This accompanies any `410` response status (both the `expiredToken` and `unregistered` reasons),
+    /// not only `unregistered`.
     public let timestamp: Date?
     
     public init(

--- a/Sources/APNSTestServer/APNSTestServer.swift
+++ b/Sources/APNSTestServer/APNSTestServer.swift
@@ -475,7 +475,7 @@ public final class APNSTestServer: @unchecked Sendable {
         headers.add(name: "content-type", value: "application/json")
 
         guard let channel = broadcastChannelsBox.withLockedValue({ $0[channelID] }) else {
-            return (.notFound, headers, "{\"reason\":\"NotFound\"}")
+            return (.badRequest, headers, "{\"reason\":\"ChannelNotRegistered\"}")
         }
 
         let responseJSON = """
@@ -489,7 +489,7 @@ public final class APNSTestServer: @unchecked Sendable {
 
         guard broadcastChannelsBox.withLockedValue({ $0.removeValue(forKey: channelID) }) != nil else {
             headers.add(name: "content-type", value: "application/json")
-            return (.notFound, headers, "{\"reason\":\"NotFound\"}")
+            return (.badRequest, headers, "{\"reason\":\"ChannelNotRegistered\"}")
         }
 
         return (.noContent, headers, "")

--- a/Tests/APNSTests/APNSClientErrorPathTests.swift
+++ b/Tests/APNSTests/APNSClientErrorPathTests.swift
@@ -1,0 +1,150 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2024 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import APNSCore
+import APNS
+import APNSTestServer
+import Crypto
+import NIOPosix
+import XCTest
+
+/// Exercises the NIO-based ``APNSClient``'s error-handling path against forced server responses,
+/// via ``APNSTestServer/setResponseOverride(_:)``. These pin the behaviour that an undecodable
+/// error body (empty, non-JSON, or oversized) must still surface as a typed `APNSError` with
+/// `reason: nil`, rather than a raw `DecodingError`/`NIOTooManyBytesError`.
+final class APNSClientErrorPathTests: XCTestCase {
+    var server: APNSTestServer!
+    var client: APNSClient<JSONDecoder, JSONEncoder>!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        server = APNSTestServer()
+        try await server.start(port: 0)
+
+        client = APNSClient(
+            configuration: .init(
+                authenticationMethod: .jwt(
+                    privateKey: try P256.Signing.PrivateKey(pemRepresentation: Self.jwtPrivateKey),
+                    keyIdentifier: "MY_KEY_ID",
+                    teamIdentifier: "MY_TEAM_ID"
+                ),
+                environment: .custom(url: "http://127.0.0.1", port: server.port)
+            ),
+            eventLoopGroupProvider: .shared(MultiThreadedEventLoopGroup.singleton),
+            responseDecoder: JSONDecoder(),
+            requestEncoder: JSONEncoder()
+        )
+    }
+
+    override func tearDown() async throws {
+        try await client?.shutdown()
+        try await server?.shutdown()
+        client = nil
+        server = nil
+        try await super.tearDown()
+    }
+
+    func testForced500_emptyBody_yieldsTypedErrorWithNilReason() async throws {
+        server.setResponseOverride(.init(status: 500))
+
+        do {
+            _ = try await client.sendAlertNotification(Self.makeAlert(), deviceToken: Self.validDeviceToken)
+            XCTFail("Expected an APNSError to be thrown")
+        } catch let error as APNSError {
+            XCTAssertEqual(error.responseStatus, 500)
+            XCTAssertNil(error.reason)
+        } catch {
+            XCTFail("Expected an APNSError, got \(type(of: error)): \(error)")
+        }
+    }
+
+    func testForced503_nonJSONBody_yieldsTypedErrorWithNilReason() async throws {
+        server.setResponseOverride(.init(status: 503, body: "<html>unavailable</html>"))
+
+        do {
+            _ = try await client.sendAlertNotification(Self.makeAlert(), deviceToken: Self.validDeviceToken)
+            XCTFail("Expected an APNSError to be thrown")
+        } catch let error as APNSError {
+            XCTAssertEqual(error.responseStatus, 503)
+            XCTAssertNil(error.reason)
+        } catch {
+            XCTFail("Expected an APNSError, got \(type(of: error)): \(error)")
+        }
+    }
+
+    func testForced429_validBody_yieldsTooManyRequestsReason() async throws {
+        server.setResponseOverride(.init(status: 429, body: #"{"reason":"TooManyRequests"}"#))
+
+        do {
+            _ = try await client.sendAlertNotification(Self.makeAlert(), deviceToken: Self.validDeviceToken)
+            XCTFail("Expected an APNSError to be thrown")
+        } catch let error as APNSError {
+            XCTAssertEqual(error.responseStatus, 429)
+            XCTAssertEqual(error.reason, .tooManyRequests)
+        }
+    }
+
+    func testForced400_oversizedBody_yieldsTypedErrorWithNilReason() async throws {
+        // Larger than the client's 1024-byte `collect(upTo:)` limit on the error path, pinning
+        // the `NIOTooManyBytesError` failure mode.
+        let garbage = String(repeating: "x", count: 2048)
+        server.setResponseOverride(.init(status: 400, body: garbage))
+
+        do {
+            _ = try await client.sendAlertNotification(Self.makeAlert(), deviceToken: Self.validDeviceToken)
+            XCTFail("Expected an APNSError to be thrown")
+        } catch let error as APNSError {
+            XCTAssertEqual(error.responseStatus, 400)
+            XCTAssertNil(error.reason)
+        } catch {
+            XCTFail("Expected an APNSError, got \(type(of: error)): \(error)")
+        }
+    }
+
+    func testForced400_channelNotRegistered_throughRealClient() async throws {
+        server.setResponseOverride(.init(status: 400, body: #"{"reason":"ChannelNotRegistered"}"#))
+
+        do {
+            _ = try await client.sendAlertNotification(Self.makeAlert(), deviceToken: Self.validDeviceToken)
+            XCTFail("Expected an APNSError to be thrown")
+        } catch let error as APNSError {
+            XCTAssertEqual(error.responseStatus, 400)
+            XCTAssertEqual(error.reason, .channelNotRegistered)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static let validDeviceToken = String(repeating: "a", count: 64)
+
+    private static func makeAlert() -> APNSAlertNotification<EmptyPayload> {
+        APNSAlertNotification(
+            alert: .init(title: .raw("title")),
+            expiration: .immediately,
+            priority: .immediately,
+            topic: "com.example.app",
+            payload: EmptyPayload()
+        )
+    }
+
+    private static let jwtPrivateKey = """
+    -----BEGIN PRIVATE KEY-----
+    MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg2sD+kukkA8GZUpmm
+    jRa4fJ9Xa/JnIG4Hpi7tNO66+OGgCgYIKoZIzj0DAQehRANCAATZp0yt0btpR9kf
+    ntp4oUUzTV0+eTELXxJxFvhnqmgwGAm1iVW132XLrdRG/ntlbQ1yzUuJkHtYBNve
+    y+77Vzsd
+    -----END PRIVATE KEY-----
+    """
+}

--- a/Tests/APNSTests/APNSErrorReasonTests.swift
+++ b/Tests/APNSTests/APNSErrorReasonTests.swift
@@ -51,6 +51,15 @@ final class APNSErrorReasonTests: XCTestCase {
         (.serviceUnavailable, "ServiceUnavailable"),
         (.shutdown, "Shutdown"),
         (.badEnvironmentKeyInToken, "BadEnvironmentKeyInToken"),
+        (.featureNotEnabled, "FeatureNotEnabled"),
+        (.missingChannelId, "MissingChannelId"),
+        (.badChannelId, "BadChannelId"),
+        (.channelNotRegistered, "ChannelNotRegistered"),
+        (.badRequestParams, "BadRequestParams"),
+        (.badRequestPayload, "BadRequestPayload"),
+        (.missingPushType, "MissingPushType"),
+        (.cannotCreateChannelConfig, "CannotCreateChannelConfig"),
+        (.topicMismatch, "TopicMismatch"),
     ]
 
     func testEveryKnownReasonRoundTrips() {
@@ -96,5 +105,42 @@ final class APNSErrorReasonTests: XCTestCase {
         let response = try JSONDecoder().decode(APNSErrorResponse.self, from: data)
         let error = APNSError(responseStatus: 400, apnsResponse: response)
         XCTAssertEqual(error.reason, .badDeviceToken)
+    }
+
+    /// The 9 broadcast/channel reasons documented at
+    /// https://developer.apple.com/documentation/usernotifications/handling-error-responses-from-apns
+    /// that this library previously lacked.
+    func testBroadcastReasonAccessors() {
+        XCTAssertEqual(APNSError.ErrorReason.featureNotEnabled.reason, "FeatureNotEnabled")
+        XCTAssertEqual(APNSError.ErrorReason.missingChannelId.reason, "MissingChannelId")
+        XCTAssertEqual(APNSError.ErrorReason.badChannelId.reason, "BadChannelId")
+        XCTAssertEqual(APNSError.ErrorReason.channelNotRegistered.reason, "ChannelNotRegistered")
+        XCTAssertEqual(APNSError.ErrorReason.badRequestParams.reason, "BadRequestParams")
+        XCTAssertEqual(APNSError.ErrorReason.badRequestPayload.reason, "BadRequestPayload")
+        XCTAssertEqual(APNSError.ErrorReason.missingPushType.reason, "MissingPushType")
+        XCTAssertEqual(APNSError.ErrorReason.cannotCreateChannelConfig.reason, "CannotCreateChannelConfig")
+        XCTAssertEqual(APNSError.ErrorReason.topicMismatch.reason, "TopicMismatch")
+    }
+
+    // MARK: - Equality / Hashable
+
+    /// `==`/`hash(into:)` compare every stored property, so two errors that differ only in
+    /// `apnsUniqueID` must NOT be considered equal, while two errors with identical properties
+    /// (including `apnsUniqueID`) must be both equal and hash-equal.
+    func testEqualityConsidersEveryProperty() throws {
+        let data = Data(#"{"reason":"BadDeviceToken"}"#.utf8)
+        let response = try JSONDecoder().decode(APNSErrorResponse.self, from: data)
+        let apnsID = UUID()
+        let uniqueID1 = UUID()
+        let uniqueID2 = UUID()
+
+        let lhs = APNSError(responseStatus: 400, apnsID: apnsID, apnsUniqueID: uniqueID1, apnsResponse: response)
+        let rhsDifferentUniqueID = APNSError(responseStatus: 400, apnsID: apnsID, apnsUniqueID: uniqueID2, apnsResponse: response)
+        let rhsSame = APNSError(responseStatus: 400, apnsID: apnsID, apnsUniqueID: uniqueID1, apnsResponse: response)
+
+        XCTAssertNotEqual(lhs, rhsDifferentUniqueID)
+
+        XCTAssertEqual(lhs, rhsSame)
+        XCTAssertEqual(lhs.hashValue, rhsSame.hashValue)
     }
 }

--- a/Tests/APNSTests/Broadcast/APNSBroadcastClientTests.swift
+++ b/Tests/APNSTests/Broadcast/APNSBroadcastClientTests.swift
@@ -88,7 +88,8 @@ final class APNSBroadcastClientTests: XCTestCase {
             _ = try await client.read(channelID: "non-existent-channel", apnsRequestID: nil)
             XCTFail("Expected error to be thrown")
         } catch let error as APNSError {
-            XCTAssertEqual(error.responseStatus, 404)
+            XCTAssertEqual(error.responseStatus, 400)
+            XCTAssertEqual(error.reason, .channelNotRegistered)
         }
     }
 
@@ -107,7 +108,8 @@ final class APNSBroadcastClientTests: XCTestCase {
             _ = try await client.read(channelID: channelID, apnsRequestID: nil)
             XCTFail("Expected error to be thrown")
         } catch let error as APNSError {
-            XCTAssertEqual(error.responseStatus, 404)
+            XCTAssertEqual(error.responseStatus, 400)
+            XCTAssertEqual(error.reason, .channelNotRegistered)
         }
     }
 
@@ -116,7 +118,8 @@ final class APNSBroadcastClientTests: XCTestCase {
             _ = try await client.delete(channelID: "non-existent-channel", apnsRequestID: nil)
             XCTFail("Expected error to be thrown")
         } catch let error as APNSError {
-            XCTAssertEqual(error.responseStatus, 404)
+            XCTAssertEqual(error.responseStatus, 400)
+            XCTAssertEqual(error.reason, .channelNotRegistered)
         }
     }
 


### PR DESCRIPTION
Replaces #247 (closed during a base-branch cleanup).

- The NIO clients threw a raw `DecodingError`/`NIOTooManyBytesError` when an APNs error body was empty, non-JSON, or oversized — losing the status code. They now return a typed `APNSError` with `reason: nil`, matching the URLSession client.
- Adds Apple's 9 documented broadcast/channel error reasons (`FeatureNotEnabled`, `MissingChannelId`, `BadChannelId`, `ChannelNotRegistered`, `BadRequestParams`, `BadRequestPayload`, `MissingPushType`, `CannotCreateChannelConfig`, `TopicMismatch`).
- Deprecates `badEnvironmentKeyInToken` (not a documented APNs reason); fixes the `timestamp` doc (accompanies any 410, not just `Unregistered`); `apnsUniqueID` is now `let`.
- Test server: read/delete of a missing channel now returns Apple's documented 400 `ChannelNotRegistered` instead of a made-up 404.
- New error-path tests (forced 500/503/429, empty/HTML/oversized bodies) via the server's response-override hook.