### PR TITLE
Add broadcast push send support

### DIFF
--- a/Sources/APNS/APNSBroadcastClient.swift
+++ b/Sources/APNS/APNSBroadcastClient.swift
@@ -75,6 +75,7 @@ public final class APNSBroadcastClient<Decoder: APNSJSONDecoder & Sendable, Enco
     ///   - responseDecoder: The decoder for the responses from APNs.
     ///   - requestEncoder: The encoder for the requests to APNs.
     ///   - byteBufferAllocator: The `ByteBufferAllocator`.
+    ///   - proxy: Upstream proxy, defaults to no proxy.
     public init(
         authenticationMethod: APNSClientConfiguration.AuthenticationMethod,
         environment: APNSBroadcastEnvironment,
@@ -82,7 +83,8 @@ public final class APNSBroadcastClient<Decoder: APNSJSONDecoder & Sendable, Enco
         eventLoopGroupProvider: NIOEventLoopGroupProvider,
         responseDecoder: Decoder,
         requestEncoder: Encoder,
-        byteBufferAllocator: ByteBufferAllocator = .init()
+        byteBufferAllocator: ByteBufferAllocator = .init(),
+        proxy: HTTPClient.Configuration.Proxy? = nil
     ) {
         self.environment = environment
         self.bundleID = bundleID
@@ -108,6 +110,7 @@ public final class APNSBroadcastClient<Decoder: APNSJSONDecoder & Sendable, Enco
         var httpClientConfiguration = HTTPClient.Configuration()
         httpClientConfiguration.tlsConfiguration = tlsConfiguration
         httpClientConfiguration.httpVersion = .automatic
+        httpClientConfiguration.proxy = proxy
 
         switch eventLoopGroupProvider {
         case .shared(let eventLoopGroup):

--- a/Sources/APNS/APNSClient.swift
+++ b/Sources/APNS/APNSClient.swift
@@ -203,4 +203,91 @@ extension APNSClient {
 
         throw error
     }
+
+    /// Publishes a broadcast push notification.
+    ///
+    /// Broadcast pushes are sent to the regular device-push host (``APNSCore/APNSEnvironment``), not the
+    /// channel-management host, and are Live Activities only.
+    ///
+    /// - Parameter request: The broadcast send request.
+    public func sendBroadcast<Message: APNSCore.APNSMessage>(
+        _ request: APNSCore.APNSBroadcastSendRequest<Message>
+    ) async throws -> APNSCore.APNSBroadcastSendResponse {
+        var headers = self.defaultRequestHeaders
+
+        // Broadcast headers (apns-channel-id, apns-push-type, apns-expiration, apns-priority, apns-request-id)
+        for (name, value) in request.headers {
+            headers.add(name: name, value: value)
+        }
+
+        // Authorization token
+        if let authenticationTokenManager = self.authenticationTokenManager {
+            let token = try await authenticationTokenManager.nextValidToken
+            headers.add(name: "authorization", value: token)
+        }
+
+        let requestURL = self.configuration.environment.broadcastSendURL(bundleID: request.bundleID)
+        var byteBuffer = self.byteBufferAllocator.buffer(capacity: 0)
+
+        try self.requestEncoder.encode(request.message, into: &byteBuffer)
+
+        var httpClientRequest = HTTPClientRequest(url: requestURL)
+        httpClientRequest.method = .POST
+        httpClientRequest.headers = headers
+        httpClientRequest.body = .bytes(byteBuffer)
+
+        let response = try await self.httpClient.execute(httpClientRequest, deadline: .distantFuture)
+
+        let apnsRequestID = response.headers.first(name: "apns-request-id").flatMap { UUID(uuidString: $0) }
+        let apnsUniqueID = response.headers.first(name: "apns-unique-id").flatMap { UUID(uuidString: $0) }
+
+        if response.status == .ok {
+            return APNSBroadcastSendResponse(apnsRequestID: apnsRequestID, apnsUniqueID: apnsUniqueID)
+        }
+
+        let body = try await response.body.collect(upTo: 1024)
+        let errorResponse = try responseDecoder.decode(APNSErrorResponse.self, from: body)
+
+        let error = APNSError(
+            responseStatus: Int(response.status.code),
+            apnsID: nil,
+            apnsUniqueID: apnsUniqueID,
+            apnsResponse: errorResponse,
+            timestamp: errorResponse.timestampInSeconds.flatMap { Date(timeIntervalSince1970: $0) }
+        )
+
+        throw error
+    }
+}
+
+// MARK: - Broadcast convenience
+
+extension APNSClient {
+
+    /// Publishes a broadcast Live Activity update (or end) notification.
+    ///
+    /// - Important: Broadcast is Live Activities only and cannot be used to *start* an activity.
+    ///
+    /// - Parameters:
+    ///   - notification: The Live Activity notification to broadcast.
+    ///   - channelID: The base64-encoded channel ID to publish the broadcast on.
+    ///   - bundleID: The app's bundle identifier used in the API path.
+    ///   - apnsRequestID: An optional request ID for tracking.
+    @discardableResult
+    public func sendBroadcastLiveActivityNotification<ContentState: Encodable & Sendable>(
+        _ notification: APNSCore.APNSLiveActivityNotification<ContentState>,
+        channelID: String,
+        bundleID: String,
+        apnsRequestID: UUID? = nil
+    ) async throws -> APNSCore.APNSBroadcastSendResponse {
+        let request = APNSCore.APNSBroadcastSendRequest(
+            message: notification,
+            channelID: channelID,
+            bundleID: bundleID,
+            expiration: notification.expiration,
+            priority: notification.priority,
+            apnsRequestID: apnsRequestID
+        )
+        return try await sendBroadcast(request)
+    }
 }

--- a/Sources/APNSCore/APNSEnvironment.swift
+++ b/Sources/APNSCore/APNSEnvironment.swift
@@ -41,6 +41,13 @@ public struct APNSEnvironment: Sendable {
     public var absoluteURL: String {
         "\(url):\(port)/3/device"
     }
-    
-    
+
+    /// The fully constructed URL for publishing a broadcast push notification.
+    ///
+    /// Broadcast pushes are sent to the regular device-push host, not the channel-management host.
+    ///
+    /// - Parameter bundleID: The app's bundle identifier.
+    public func broadcastSendURL(bundleID: String) -> String {
+        "\(url):\(port)/4/broadcasts/apps/\(bundleID)"
+    }
 }

--- a/Sources/APNSCore/Broadcast/APNSBroadcastSendRequest.swift
+++ b/Sources/APNSCore/Broadcast/APNSBroadcastSendRequest.swift
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2025 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import struct FoundationEssentials.UUID
+#else
+import struct Foundation.UUID
+#endif
+
+/// Represents a request to publish a broadcast push notification.
+///
+/// Broadcast pushes are sent to the regular device-push host (``APNSEnvironment``), not the
+/// channel-management host, at `POST /4/broadcasts/apps/<bundle ID>`. They are Live Activities only
+/// and cannot be used to start an activity.
+///
+/// See: https://developer.apple.com/documentation/usernotifications/sending-broadcast-push-notification-requests-to-apns
+public struct APNSBroadcastSendRequest<Message: APNSMessage>: Sendable {
+    /// The message payload to broadcast.
+    public let message: Message
+
+    /// The base64-encoded channel ID to publish the broadcast on.
+    public let channelID: String
+
+    /// The app's bundle identifier used in the API path.
+    public let bundleID: String
+
+    /// The date when the notification is no longer valid and can be discarded.
+    public let expiration: APNSNotificationExpiration
+
+    /// The priority of the notification.
+    public let priority: APNSPriority
+
+    /// An optional request ID for tracking. If you omit this, APNs creates a new UUID and returns it in the response.
+    public let apnsRequestID: UUID?
+
+    /// Creates a broadcast send request.
+    ///
+    /// - Parameters:
+    ///   - message: The message payload to broadcast.
+    ///   - channelID: The base64-encoded channel ID to publish the broadcast on.
+    ///   - bundleID: The app's bundle identifier used in the API path.
+    ///   - expiration: The date when the notification is no longer valid and can be discarded.
+    ///   - priority: The priority of the notification.
+    ///   - apnsRequestID: An optional request ID for tracking.
+    public init(
+        message: Message,
+        channelID: String,
+        bundleID: String,
+        expiration: APNSNotificationExpiration,
+        priority: APNSPriority,
+        apnsRequestID: UUID? = nil
+    ) {
+        self.message = message
+        self.channelID = channelID
+        self.bundleID = bundleID
+        self.expiration = expiration
+        self.priority = priority
+        self.apnsRequestID = apnsRequestID
+    }
+
+    /// The HTTP headers required (and optional) by APNs for a broadcast send request.
+    ///
+    /// - Note: Unlike a regular device push, `apns-expiration` and `apns-priority` are always emitted
+    /// since Apple requires both headers on broadcast requests.
+    public var headers: [(String, String)] {
+        var computedHeaders: [(String, String)] = []
+
+        /// Channel ID
+        computedHeaders.append(("apns-channel-id", channelID))
+
+        /// Push type — broadcast only supports `liveactivity`.
+        computedHeaders.append(("apns-push-type", "liveactivity"))
+
+        /// Expiration — required by Apple, so `.none` is sent as `0`.
+        computedHeaders.append(("apns-expiration", "\(expiration.expiration ?? 0)"))
+
+        /// Priority — required by Apple.
+        computedHeaders.append(("apns-priority", "\(priority.rawValue)"))
+
+        /// Request ID
+        if let apnsRequestID {
+            computedHeaders.append(("apns-request-id", apnsRequestID.uuidString.lowercased()))
+        }
+
+        return computedHeaders
+    }
+}

--- a/Sources/APNSCore/Broadcast/APNSBroadcastSendResponse.swift
+++ b/Sources/APNSCore/Broadcast/APNSBroadcastSendResponse.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2025 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import struct FoundationEssentials.UUID
+#else
+import struct Foundation.UUID
+#endif
+
+/// Represents a response from publishing a broadcast push notification.
+public struct APNSBroadcastSendResponse: Sendable, Hashable {
+    /// The request ID returned by APNs, either echoing the one sent in the request or a newly generated one.
+    public let apnsRequestID: UUID?
+
+    /// A unique ID for the broadcast notification, as determined by the APNs servers.
+    public let apnsUniqueID: UUID?
+
+    public init(apnsRequestID: UUID?, apnsUniqueID: UUID?) {
+        self.apnsRequestID = apnsRequestID
+        self.apnsUniqueID = apnsUniqueID
+    }
+}

--- a/Sources/APNSTestServer/APNSTestServer.swift
+++ b/Sources/APNSTestServer/APNSTestServer.swift
@@ -26,9 +26,10 @@ import struct Foundation.CharacterSet
 
 /// A comprehensive mock server that simulates Apple Push Notification service APIs.
 ///
-/// This server supports both:
+/// This server supports:
 /// - **Regular push notifications**: `POST /3/device/{token}`
 /// - **Broadcast channels**: `POST/GET/DELETE /1/apps/{bundleID}/channels` (+ `GET /1/apps/{bundleID}/all-channels`)
+/// - **Broadcast send**: `POST /4/broadcasts/apps/{bundleID}`
 ///
 /// ## Usage
 ///
@@ -54,6 +55,7 @@ public final class APNSTestServer: @unchecked Sendable {
     private let broadcastChannelsBox = NIOLockedValueBox<[String: MockBroadcastChannel]>([:])
     private let sentNotificationsBox = NIOLockedValueBox<[SentNotification]>([])
     private let broadcastRequestsBox = NIOLockedValueBox<[BroadcastRequestRecord]>([])
+    private let broadcastSendsBox = NIOLockedValueBox<[BroadcastSendRecord]>([])
     private let responseOverrideBox = NIOLockedValueBox<ResponseOverride?>(nil)
 
     public var port: Int {
@@ -90,6 +92,29 @@ public final class APNSTestServer: @unchecked Sendable {
         public let apnsRequestID: String?
         /// The `apns-channel-id` header the client sent, if any.
         public let apnsChannelID: String?
+    }
+
+    /// Metadata captured about a broadcast push notification sent to
+    /// `POST /4/broadcasts/apps/{bundleID}`.
+    public struct BroadcastSendRecord: Sendable {
+        /// The app's bundle identifier the broadcast was sent to.
+        public let bundleID: String
+        /// The `apns-channel-id` header the client sent.
+        public let channelID: String
+        /// The `apns-request-id` header the client sent, if any.
+        public let receivedRequestID: String?
+        /// The `apns-push-type` header the client sent.
+        public let pushType: String
+        /// The `apns-expiration` header the client sent.
+        public let expiration: String
+        /// The `apns-priority` header the client sent.
+        public let priority: String
+        /// The raw JSON payload the client sent.
+        public let payload: Data
+
+        public func decodedPayload<T: Decodable>(as type: T.Type) throws -> T {
+            try JSONDecoder().decode(type, from: payload)
+        }
     }
 
     /// A forced response for the *next* `/3/device/{token}` request, letting tests simulate
@@ -187,6 +212,11 @@ public final class APNSTestServer: @unchecked Sendable {
     /// Returns all requests made to broadcast/channel management endpoints.
     public func getBroadcastRequests() -> [BroadcastRequestRecord] {
         broadcastRequestsBox.withLockedValue { $0 }
+    }
+
+    /// Returns all broadcast push notifications sent to `POST /4/broadcasts/apps/{bundleID}`.
+    public func getBroadcastSends() -> [BroadcastSendRecord] {
+        broadcastSendsBox.withLockedValue { $0 }
     }
 
     /// Forces the *next* `/3/device/{token}` response to be exactly `override`, bypassing all normal
@@ -290,41 +320,56 @@ public final class APNSTestServer: @unchecked Sendable {
 
         let isAppsPath = components.count >= 2 && components[0] == "1" && components[1] == "apps"
         let isDevicePushAttempt = components.count >= 2 && components[0] == "3" && components[1] == "device"
+        let isBroadcastSendAttempt = components.count >= 2 && components[0] == "4" && components[1] == "broadcasts"
 
         if isAppsPath {
             recordBroadcastRequest(uri: uri, method: method, headers: headers)
         }
 
-        // Authorization is validated before all other request validation on device-push and
-        // broadcast/channel endpoints.
-        if isAppsPath || isDevicePushAttempt {
+        // Authorization is validated before all other request validation on device-push,
+        // broadcast/channel, and broadcast-send endpoints.
+        if isAppsPath || isDevicePushAttempt || isBroadcastSendAttempt {
             if let failure = Self.validateAuthorization(headers: headers) {
                 var responseHeaders = HTTPHeaders()
                 responseHeaders.add(name: "content-type", value: "application/json")
                 let result = (failure.status, responseHeaders, "{\"reason\":\"\(failure.reason)\"}")
-                return finalize(result, isDevicePush: isDevicePushAttempt, isBroadcast: isAppsPath, requestHeaders: headers)
+                return finalize(
+                    result,
+                    isDevicePush: isDevicePushAttempt,
+                    isBroadcast: isAppsPath,
+                    isBroadcastSend: isBroadcastSendAttempt,
+                    requestHeaders: headers
+                )
             }
         }
 
         let result = dispatch(method: method, components: components, headers: headers, body: body)
-        return finalize(result, isDevicePush: isDevicePushAttempt, isBroadcast: isAppsPath, requestHeaders: headers)
+        return finalize(
+            result,
+            isDevicePush: isDevicePushAttempt,
+            isBroadcast: isAppsPath,
+            isBroadcastSend: isBroadcastSendAttempt,
+            requestHeaders: headers
+        )
     }
 
     /// Adds the response headers that are consistent across an entire path family
-    /// (`apns-unique-id` for device pushes, `apns-request-id` for broadcast/channel operations).
+    /// (`apns-unique-id` for device pushes, `apns-request-id` for broadcast/channel operations,
+    /// and both `apns-request-id`/`apns-unique-id` for broadcast-send).
     private func finalize(
         _ result: (status: HTTPResponseStatus, headers: HTTPHeaders, body: String),
         isDevicePush: Bool,
         isBroadcast: Bool,
+        isBroadcastSend: Bool,
         requestHeaders: HTTPHeaders
     ) -> (status: HTTPResponseStatus, headers: HTTPHeaders, body: String) {
         var responseHeaders = result.headers
 
-        if isDevicePush && !responseHeaders.contains(name: "apns-unique-id") {
+        if (isDevicePush || isBroadcastSend) && !responseHeaders.contains(name: "apns-unique-id") {
             responseHeaders.add(name: "apns-unique-id", value: UUID().uuidString)
         }
 
-        if isBroadcast && !responseHeaders.contains(name: "apns-request-id") {
+        if (isBroadcast || isBroadcastSend) && !responseHeaders.contains(name: "apns-request-id") {
             let requestID = requestHeaders.first(name: "apns-request-id") ?? UUID().uuidString
             responseHeaders.add(name: "apns-request-id", value: requestID)
         }
@@ -389,6 +434,29 @@ public final class APNSTestServer: @unchecked Sendable {
             switch method {
             case .GET:
                 return handleListChannels()
+            default:
+                var responseHeaders = HTTPHeaders()
+                responseHeaders.add(name: "content-type", value: "application/json")
+                return (.methodNotAllowed, responseHeaders, "{\"reason\":\"MethodNotAllowed\"}")
+            }
+        }
+
+        // Broadcast send endpoint: POST /4/broadcasts/apps/{bundleID}
+        let isBroadcastSendPath = components.count >= 3
+            && components[0] == "4" && components[1] == "broadcasts" && components[2] == "apps"
+
+        if isBroadcastSendPath {
+            guard components.count == 4 else {
+                var responseHeaders = HTTPHeaders()
+                responseHeaders.add(name: "content-type", value: "application/json")
+                return (.notFound, responseHeaders, "{\"reason\":\"BadPath\"}")
+            }
+
+            let bundleID = String(components[3])
+
+            switch method {
+            case .POST:
+                return handleBroadcastSend(bundleID: bundleID, headers: headers, body: body)
             default:
                 var responseHeaders = HTTPHeaders()
                 responseHeaders.add(name: "content-type", value: "application/json")
@@ -493,6 +561,87 @@ public final class APNSTestServer: @unchecked Sendable {
         }
 
         return (.noContent, headers, "")
+    }
+
+    // MARK: - Broadcast Send Handler
+
+    /// Handles `POST /4/broadcasts/apps/{bundleID}`, i.e. publishing a broadcast push.
+    ///
+    /// Unlike channel management (`/1/apps/...`), broadcast sends live on the regular device-push
+    /// host and are validated similarly to `/3/device/{token}`, but against broadcast-specific rules.
+    /// See: https://developer.apple.com/documentation/usernotifications/sending-broadcast-push-notification-requests-to-apns
+    private func handleBroadcastSend(
+        bundleID: String,
+        headers: HTTPHeaders,
+        body: ByteBuffer?
+    ) -> (status: HTTPResponseStatus, headers: HTTPHeaders, body: String) {
+        func badRequest(_ reason: String) -> (status: HTTPResponseStatus, headers: HTTPHeaders, body: String) {
+            var responseHeaders = HTTPHeaders()
+            responseHeaders.add(name: "content-type", value: "application/json")
+            return (.badRequest, responseHeaders, "{\"reason\":\"\(reason)\"}")
+        }
+
+        guard let channelID = headers.first(name: "apns-channel-id") else {
+            return badRequest("MissingChannelId")
+        }
+
+        guard let pushType = headers.first(name: "apns-push-type") else {
+            return badRequest("MissingPushType")
+        }
+
+        // Broadcast only supports Live Activity updates/ends; it cannot start an activity.
+        guard pushType == "liveactivity" else {
+            return badRequest("InvalidPushType")
+        }
+
+        guard let expiration = headers.first(name: "apns-expiration"), Int(expiration) != nil else {
+            return badRequest("BadExpirationDate")
+        }
+
+        guard let priority = headers.first(name: "apns-priority"),
+              priority == "1" || priority == "5" || priority == "10"
+        else {
+            return badRequest("BadPriority")
+        }
+
+        let channelIsRegistered = broadcastChannelsBox.withLockedValue { $0[channelID] != nil }
+        guard channelIsRegistered else {
+            return badRequest("ChannelNotRegistered")
+        }
+
+        guard var bodyBuffer = body,
+              let bytes = bodyBuffer.readBytes(length: bodyBuffer.readableBytes),
+              !bytes.isEmpty
+        else {
+            return badRequest("PayloadEmpty")
+        }
+
+        let payload = Data(bytes)
+
+        guard (try? JSONSerialization.jsonObject(with: payload)) != nil else {
+            return badRequest("PayloadEmpty")
+        }
+
+        if payload.count > 5120 {
+            var responseHeaders = HTTPHeaders()
+            responseHeaders.add(name: "content-type", value: "application/json")
+            return (.payloadTooLarge, responseHeaders, "{\"reason\":\"PayloadTooLarge\"}")
+        }
+
+        let record = BroadcastSendRecord(
+            bundleID: bundleID,
+            channelID: channelID,
+            receivedRequestID: headers.first(name: "apns-request-id"),
+            pushType: pushType,
+            expiration: expiration,
+            priority: priority,
+            payload: payload
+        )
+        broadcastSendsBox.withLockedValue { $0.append(record) }
+
+        var responseHeaders = HTTPHeaders()
+        responseHeaders.add(name: "content-type", value: "application/json")
+        return (.ok, responseHeaders, "{}")
     }
 
     // MARK: - Push Notification Handler

--- a/Sources/APNSURLSession/APNSUrlSessionClient.swift
+++ b/Sources/APNSURLSession/APNSUrlSessionClient.swift
@@ -65,6 +65,55 @@ public struct APNSURLSessionClient: APNSClientProtocol {
         )
     }
 
+    /// Publishes a broadcast push notification.
+    ///
+    /// Broadcast pushes are sent to the regular device-push host (``APNSEnvironment``), not the
+    /// channel-management host, and are Live Activities only.
+    ///
+    /// - Parameter request: The broadcast send request.
+    public func sendBroadcast<Message: APNSMessage>(
+        _ request: APNSBroadcastSendRequest<Message>
+    ) async throws -> APNSBroadcastSendResponse {
+
+        /// Construct URL
+        var urlRequest = URLRequest(url: URL(string: configuration.environment.broadcastSendURL(bundleID: request.bundleID))!)
+        urlRequest.httpMethod = "POST"
+        /// Set headers
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        for (header, value) in request.headers {
+            urlRequest.setValue(value, forHTTPHeaderField: header)
+        }
+
+        await urlRequest.setValue(try configuration.nextValidToken(), forHTTPHeaderField: "Authorization")
+
+        /// Set Body
+        urlRequest.httpBody = try encoder.encode(request.message)
+
+        /// Make request
+        let (data, response) = try await URLSession.shared.data(for: urlRequest)
+
+        /// Unwrap response
+        guard let response = response as? HTTPURLResponse else {
+            throw APNSUrlSessionClientError.urlResponseNotFound
+        }
+
+        let apnsRequestID = response.value(forHTTPHeaderField: "apns-request-id").flatMap { UUID(uuidString: $0) }
+        let apnsUniqueID = response.value(forHTTPHeaderField: "apns-unique-id").flatMap { UUID(uuidString: $0) }
+
+        if response.statusCode == 200 {
+            return APNSBroadcastSendResponse(apnsRequestID: apnsRequestID, apnsUniqueID: apnsUniqueID)
+        }
+
+        let errorResponse = try? decoder.decode(APNSErrorResponse.self, from: data)
+        throw APNSError(
+            responseStatus: response.statusCode,
+            apnsID: nil,
+            apnsUniqueID: apnsUniqueID,
+            apnsResponse: errorResponse,
+            timestamp: errorResponse?.timestampInSeconds.flatMap { Date(timeIntervalSince1970: $0) }
+        )
+    }
+
     public func shutdown() async throws {
         // no op
     }

--- a/Tests/APNSTests/Broadcast/APNSBroadcastSendTests.swift
+++ b/Tests/APNSTests/Broadcast/APNSBroadcastSendTests.swift
@@ -1,0 +1,240 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2025 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import APNSCore
+import APNS
+import APNSTestServer
+import Crypto
+import NIOPosix
+import XCTest
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import APNSURLSession
+#endif
+
+/// Exercises `POST /4/broadcasts/apps/{bundleID}` end-to-end against `APNSTestServer`.
+///
+/// Channel CRUD goes through ``APNSBroadcastClient`` (the `/1/apps/...` management host), while
+/// broadcast *send* goes through the regular device-push ``APNSClient`` (the `/4/broadcasts/apps/...`
+/// path lives on the same host as `/3/device/...`). Both clients are pointed at the same mock server.
+final class APNSBroadcastSendTests: XCTestCase {
+    var server: APNSTestServer!
+    var broadcastClient: APNSBroadcastClient<JSONDecoder, JSONEncoder>!
+    var client: APNSClient<JSONDecoder, JSONEncoder>!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        server = APNSTestServer()
+        try await server.start(port: 0)
+
+        let serverPort = server.port
+
+        broadcastClient = APNSBroadcastClient(
+            authenticationMethod: .jwt(
+                privateKey: try P256.Signing.PrivateKey(pemRepresentation: Self.jwtPrivateKey),
+                keyIdentifier: "MY_KEY_ID",
+                teamIdentifier: "MY_TEAM_ID"
+            ),
+            environment: .custom(url: "http://127.0.0.1", port: serverPort),
+            bundleID: Self.bundleID,
+            eventLoopGroupProvider: .shared(MultiThreadedEventLoopGroup.singleton),
+            responseDecoder: JSONDecoder(),
+            requestEncoder: JSONEncoder()
+        )
+
+        client = APNSClient(
+            configuration: .init(
+                authenticationMethod: .jwt(
+                    privateKey: try P256.Signing.PrivateKey(pemRepresentation: Self.jwtPrivateKey),
+                    keyIdentifier: "MY_KEY_ID",
+                    teamIdentifier: "MY_TEAM_ID"
+                ),
+                environment: .custom(url: "http://127.0.0.1", port: serverPort)
+            ),
+            eventLoopGroupProvider: .shared(MultiThreadedEventLoopGroup.singleton),
+            responseDecoder: JSONDecoder(),
+            requestEncoder: JSONEncoder()
+        )
+    }
+
+    override func tearDown() async throws {
+        try await broadcastClient?.shutdown()
+        try await client?.shutdown()
+        try await server?.shutdown()
+        broadcastClient = nil
+        client = nil
+        server = nil
+        try await super.tearDown()
+    }
+
+    func testSendBroadcastLiveActivityUpdate_success() async throws {
+        let channelID = try await createChannel()
+
+        let response = try await client.sendBroadcastLiveActivityNotification(
+            Self.makeUpdate(),
+            channelID: channelID,
+            bundleID: Self.bundleID
+        )
+
+        XCTAssertNotNil(response.apnsRequestID)
+        XCTAssertNotNil(response.apnsUniqueID)
+
+        let sends = server.getBroadcastSends()
+        XCTAssertEqual(sends.count, 1)
+
+        let sent = try XCTUnwrap(sends.first)
+        XCTAssertEqual(sent.bundleID, Self.bundleID)
+        XCTAssertEqual(sent.channelID, channelID)
+        XCTAssertEqual(sent.pushType, "liveactivity")
+
+        let payload = try sent.decodedPayload(as: BroadcastPayload.self)
+        XCTAssertEqual(payload.aps.event, "update")
+    }
+
+    func testSendBroadcast_requestIDEcho() async throws {
+        let channelID = try await createChannel()
+        let requestID = UUID()
+
+        let response = try await client.sendBroadcastLiveActivityNotification(
+            Self.makeUpdate(),
+            channelID: channelID,
+            bundleID: Self.bundleID,
+            apnsRequestID: requestID
+        )
+
+        XCTAssertEqual(response.apnsRequestID, requestID)
+
+        let sent = try XCTUnwrap(server.getBroadcastSends().first)
+        XCTAssertEqual(sent.receivedRequestID, requestID.uuidString.lowercased())
+    }
+
+    func testSendBroadcast_channelNotRegistered() async throws {
+        do {
+            _ = try await client.sendBroadcastLiveActivityNotification(
+                Self.makeUpdate(),
+                channelID: UUID().uuidString,
+                bundleID: Self.bundleID
+            )
+            XCTFail("Expected an APNSError to be thrown")
+        } catch let error as APNSError {
+            // A parallel PR may add a typed `.channelNotRegistered` reason; keep this robust
+            // against that by only asserting the status code here.
+            XCTAssertEqual(error.responseStatus, 400)
+        }
+    }
+
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    func testSendBroadcastLiveActivityUpdate_urlSessionClient_success() async throws {
+        let channelID = try await createChannel()
+
+        let urlSessionClient = APNSURLSessionClient(
+            configuration: .init(
+                environment: .custom(url: "http://127.0.0.1", port: server.port),
+                privateKey: try P256.Signing.PrivateKey(pemRepresentation: Self.jwtPrivateKey),
+                keyIdentifier: "MY_KEY_ID",
+                teamIdentifier: "MY_TEAM_ID"
+            )
+        )
+
+        let request = APNSBroadcastSendRequest(
+            message: Self.makeUpdate(),
+            channelID: channelID,
+            bundleID: Self.bundleID,
+            expiration: .immediately,
+            priority: .immediately
+        )
+
+        let response = try await urlSessionClient.sendBroadcast(request)
+
+        XCTAssertNotNil(response.apnsRequestID)
+        XCTAssertNotNil(response.apnsUniqueID)
+
+        let sends = server.getBroadcastSends()
+        XCTAssertEqual(sends.count, 1)
+        XCTAssertEqual(sends.first?.channelID, channelID)
+    }
+    #endif
+
+    func testSendBroadcast_payloadTooLarge() async throws {
+        let channelID = try await createChannel()
+
+        // Comfortably over the 5,120-byte broadcast payload limit.
+        let oversizedState = LargeContentState(text: String(repeating: "x", count: 6000))
+        let notification = APNSLiveActivityNotification(
+            expiration: .immediately,
+            priority: .immediately,
+            appID: Self.bundleID,
+            contentState: oversizedState,
+            event: .update,
+            timestamp: 0
+        )
+
+        do {
+            _ = try await client.sendBroadcastLiveActivityNotification(
+                notification,
+                channelID: channelID,
+                bundleID: Self.bundleID
+            )
+            XCTFail("Expected an APNSError to be thrown")
+        } catch let error as APNSError {
+            XCTAssertEqual(error.responseStatus, 413)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static let bundleID = "com.example.testapp"
+
+    private func createChannel() async throws -> String {
+        let channel = APNSBroadcastChannel(messageStoragePolicy: .mostRecentMessageStored)
+        let response = try await broadcastClient.create(channel: channel, apnsRequestID: nil)
+        return try XCTUnwrap(response.channelID)
+    }
+
+    private static func makeUpdate() -> APNSLiveActivityNotification<ExampleContentState> {
+        APNSLiveActivityNotification(
+            expiration: .immediately,
+            priority: .immediately,
+            appID: Self.bundleID,
+            contentState: ExampleContentState(message: "hello"),
+            event: .update,
+            timestamp: 0
+        )
+    }
+
+    private struct ExampleContentState: Codable, Sendable {
+        let message: String
+    }
+
+    private struct LargeContentState: Codable, Sendable {
+        let text: String
+    }
+
+    private struct BroadcastPayload: Decodable {
+        struct APS: Decodable {
+            let event: String
+        }
+        let aps: APS
+    }
+
+    private static let jwtPrivateKey = """
+    -----BEGIN PRIVATE KEY-----
+    MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg2sD+kukkA8GZUpmm
+    jRa4fJ9Xa/JnIG4Hpi7tNO66+OGgCgYIKoZIzj0DAQehRANCAATZp0yt0btpR9kf
+    ntp4oUUzTV0+eTELXxJxFvhnqmgwGAm1iVW132XLrdRG/ntlbQ1yzUuJkHtYBNve
+    y+77Vzsd
+    -----END PRIVATE KEY-----
+    """
+}


### PR DESCRIPTION
Replaces #248 (closed during a base-branch cleanup).

The library could manage broadcast channels but had no way to publish to one. Adds `POST /4/broadcasts/apps/<bundleID>` support per Apple's docs:

- `APNSBroadcastSendRequest`/`APNSBroadcastSendResponse` in APNSCore with the required headers (`apns-channel-id`, `apns-push-type: liveactivity`, `apns-expiration`, `apns-priority`, optional `apns-request-id`).
- `sendBroadcast(_:)` on both clients plus a `sendBroadcastLiveActivityNotification(...)` convenience; `APNSEnvironment.broadcastSendURL(bundleID:)`.
- Test-server endpoint with Apple's documented validation chain (`MissingChannelId` → `MissingPushType` → `InvalidPushType` → `BadExpirationDate` → `BadPriority` → `ChannelNotRegistered` → `PayloadEmpty` → 413 at 5 KB) and a broadcast-send log for assertions.
- Drift fix: `APNSBroadcastClient` now supports a proxy like `APNSClient` does.